### PR TITLE
Python port: core engine, state store, audit tool

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: install tcl + tkinter
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends python3-tk tcl
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync --group dev
+      - run: uv run pytest -v

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
 app/lib/Shittybot/Logger.pm
 vol
+__pycache__/
+*.pyc
+.venv/
+.pytest_cache/
+*.egg-info/
+dist/
+state-local*/
+state/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,83 @@
+# smeggdrop
+
+Evaluates Tcl in chat rooms. Say `tcl expr {6 * 7}` in a channel and the bot
+answers `42`. Procs and variables defined in chat persist — the interpreter's
+state is snapshotted, diffed and written to disk after every eval, so a
+channel accumulates a shared library of procs over the years.
+
+A fork of Sam Stephenson's smeggdrop, by way of the perl "shittybot" era
+(still in [`app/`](app/) until the port is done). The current implementation
+is Python; the interpreter is real Tcl via the stdlib's `tkinter` binding —
+no Tk, no display, no native extensions. Plan and progress: [#2](https://github.com/revmischa/smeggdrop/issues/2).
+
+## Running
+
+Needs Python ≥ 3.11 with tkinter (Debian/Ubuntu: `apt install python3-tk`).
+
+```sh
+uv sync
+
+# hack on the interpreter locally, no chat platform needed
+uv run smeggdrop --state state-local repl
+
+# check every saved proc in a state dir: loads? runs? references dead commands?
+uv run smeggdrop --state state-local audit
+uv run smeggdrop --state state-local audit --json > report.json
+
+uv run pytest
+```
+
+The state directory format is unchanged from the perl bot (sha1-named
+proc/var files plus an `_index` per category), so an existing state dir
+works as-is.
+
+`audit` exists so the port can be verified against real accumulated state:
+it loads everything into a throwaway sandbox (nothing persisted, network
+stubbed out), flags procs that fail to load or reference commands that no
+longer exist, and actually calls every proc that's callable without
+arguments. Fix, re-run, repeat.
+
+## Security model
+
+All chat input is untrusted and gets evaluated anyway — that's the product —
+so containment is layered:
+
+- code runs in a Tcl `interp create -safe` slave: no `exec`, `open`, `file`,
+  `socket`, `source`, env access, or filesystem
+- every eval has a wall-clock limit enforced by the master interp; slaves
+  cannot modify their own limits
+- host values (nick, channel, code) cross into Tcl as quoted list words,
+  never by string interpolation
+- `core::curl` (the sandbox's only network access) allows plain http(s) to
+  public addresses only — no loopback/RFC1918/link-local/metadata/CGNAT
+  targets, redirects re-validated per hop, responses size-capped — and is
+  call-limited per eval
+- `core::bot_say` is call-limited per eval; eval output is truncated before
+  it reaches a platform
+- persistence is vetted: per-eval caps on change count and value size, and
+  names that would corrupt the index format are refused (state files are
+  named by sha1, so names never become paths)
+
+Residual risks worth knowing: DNS rebinding can slip past the fetcher's
+resolve-time checks (run the bot with no reachable internal network — a
+Lambda outside any VPC — and it's moot), and Tcl has no per-interp memory
+cap (a hostile eval can balloon the process; process-level limits are the
+backstop).
+
+## Architecture
+
+```
+smeggdrop/
+  interp.py     safe slave interp: bootstrap, context, per-eval limits
+  engine.py     versioned eval: snapshot -> eval -> diff -> persist
+  state.py      file store, byte-compatible with the perl layout
+  security.py   SSRF-guarded fetcher behind core::curl
+  audit.py      state verification (the `audit` subcommand)
+  platforms/    adapters; the engine never imports platform SDKs
+  tcl/          bootstrap sourced into the slave (from the perl tree)
+```
+
+Platform adapters do three things: decide whether a message triggers an
+eval, build an `EvalRequest`, deliver the reply. Slack (Events API +
+Lambda, Socket Mode for dev) is next; Discord is a planned adapter via the
+interactions endpoint.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[project]
+name = "smeggdrop"
+version = "0.1.0"
+description = "Evaluates Tcl in chat rooms. Interpreter state is persistent and versioned."
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.11"
+dependencies = []
+
+[project.optional-dependencies]
+slack = ["slack-bolt>=1.20"]
+
+[project.scripts]
+smeggdrop = "smeggdrop.cli:main"
+
+[dependency-groups]
+dev = ["pytest>=8"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["smeggdrop"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/smeggdrop/__init__.py
+++ b/smeggdrop/__init__.py
@@ -1,0 +1,6 @@
+"""smeggdrop: evaluates Tcl in chat rooms, with persistent versioned state."""
+
+from smeggdrop.engine import Engine, EvalRequest, EvalResult, Limits
+from smeggdrop.state import FileStateStore
+
+__all__ = ["Engine", "EvalRequest", "EvalResult", "Limits", "FileStateStore"]

--- a/smeggdrop/audit.py
+++ b/smeggdrop/audit.py
@@ -1,0 +1,169 @@
+"""Audit saved state: which procs load, reference dead commands, or crash.
+
+The runtime state has years of procs written in chat against the old
+interpreter — tclcurl-era http helpers, eggdrop leftovers. This loads a
+state dir into a throwaway sandbox and reports, per proc:
+
+- does it install cleanly (`proc` succeeds)?
+- does its body reference commands that don't exist? split into
+  `broken_refs` (known-hidden safe-interp commands and dead library
+  prefixes — definitely broken) and `unknown_refs` (heuristic: a word in
+  command position that resolves to nothing — may be a false positive for
+  data words in braces)
+- if it's callable with zero args, does it actually run?
+
+Nothing is persisted: the audit interp never touches a save path, curl is
+stubbed out, bot_say is captured. Use this after syncing the production
+state dir to see exactly what the port broke, fix, re-run, repeat.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import asdict, dataclass, field
+
+from smeggdrop.interp import SafeTclInterp, TclError
+from smeggdrop.state import StateStore
+
+# hidden in safe interps: anything referencing these is broken by design
+SAFE_HIDDEN = {
+    "cd", "encoding", "exec", "exit", "fconfigure", "file", "glob",
+    "load", "open", "pwd", "socket", "source", "unload", "vwait",
+}
+# gone with the perl host process
+DEAD_PREFIXES = ("http::", "curl::", "twitter::", "tclcurl")
+
+# a bareword in command position: start of script/line, or after [ or ;
+CMD_POSITION = re.compile(r"(?:^|[\[;\n])\s*([A-Za-z_][\w:.@?!+-]*)", re.M)
+
+
+@dataclass
+class ProcAudit:
+    name: str
+    loaded: bool = True
+    load_error: str | None = None
+    broken_refs: list[str] = field(default_factory=list)
+    unknown_refs: list[str] = field(default_factory=list)
+    ran: bool = False
+    run_ok: bool | None = None
+    run_error: str | None = None
+
+    @property
+    def healthy(self) -> bool:
+        return self.loaded and not self.broken_refs and self.run_ok is not False
+
+
+@dataclass
+class AuditReport:
+    procs: list[ProcAudit]
+    var_load_errors: dict[str, str]
+
+    def summary(self) -> dict[str, int]:
+        return {
+            "total": len(self.procs),
+            "load_failures": sum(1 for p in self.procs if not p.loaded),
+            "broken_refs": sum(1 for p in self.procs if p.broken_refs),
+            "unknown_refs": sum(1 for p in self.procs if p.unknown_refs),
+            "ran": sum(1 for p in self.procs if p.ran),
+            "run_failures": sum(1 for p in self.procs if p.run_ok is False),
+            "var_load_failures": len(self.var_load_errors),
+        }
+
+    def to_dict(self) -> dict:
+        return {
+            "summary": self.summary(),
+            "procs": [asdict(p) for p in self.procs],
+            "var_load_errors": self.var_load_errors,
+        }
+
+
+def audit_state(
+    store: StateStore,
+    *,
+    tcl_dir=None,
+    run: bool = True,
+    time_limit: int = 2,
+) -> AuditReport:
+    said: list[str] = []
+    interp = SafeTclInterp(
+        tcl_dir=tcl_dir,
+        builtins={
+            "core::print": lambda *a: "",
+            "core::sha1": lambda t="": hashlib.sha1(str(t).encode()).hexdigest(),
+            "core::bot_say": lambda *a: said.append(" ".join(str(x) for x in a)) or "",
+            "core::curl": _curl_stub,
+            "core::words": lambda: (),
+        },
+    )
+    try:
+        reports: dict[str, ProcAudit] = {}
+        for name, payload in sorted(store.load("procs").items()):
+            report = ProcAudit(name)
+            try:
+                interp.install_proc(name, payload)
+            except TclError as e:
+                report.loaded = False
+                report.load_error = str(e)
+            reports[name] = report
+
+        var_errors: dict[str, str] = {}
+        for name, payload in sorted(store.load("vars").items()):
+            try:
+                interp.install_var(name, payload)
+            except (TclError, ValueError) as e:
+                var_errors[name] = str(e)
+
+        interp.alias_global_commands()
+
+        for name, report in reports.items():
+            if not report.loaded:
+                continue
+            body = interp.eval(("info", "body", name))
+            for ref in sorted(set(CMD_POSITION.findall(body))):
+                if ref == name:
+                    continue
+                if interp.eval(("info", "commands", ref)) != "":
+                    continue
+                if ref in SAFE_HIDDEN or ref.startswith(DEAD_PREFIXES):
+                    report.broken_refs.append(ref)
+                else:
+                    report.unknown_refs.append(ref)
+
+        if run:
+            interp.set_context(
+                nick="audit", mask="audit@audit", channel="#audit",
+                command="", nicks=("audit",),
+            )
+            interp.set_command_vars(nick="audit", mask="audit@audit", channel="#audit", line="")
+            for name, report in reports.items():
+                if not report.loaded or not _callable_without_args(interp, name):
+                    continue
+                report.ran = True
+                try:
+                    interp.eval_limited((name,), time_limit)
+                    report.run_ok = True
+                except TclError as e:
+                    report.run_ok = False
+                    report.run_error = str(e)
+
+        return AuditReport(list(reports.values()), var_errors)
+    finally:
+        interp.close()
+
+
+def _curl_stub(*args):
+    raise TclError("core::curl is disabled during audit")
+
+
+def _callable_without_args(interp: SafeTclInterp, name: str) -> bool:
+    try:
+        args = interp.splitlist(interp.eval(("info", "args", name)))
+    except TclError:
+        return False
+    for arg in args:
+        if arg == "args":
+            continue  # varargs: zero is fine
+        if interp.eval(("info", "default", name, arg, "::_audit_default")) != "1":
+            return False
+    return True

--- a/smeggdrop/cli.py
+++ b/smeggdrop/cli.py
@@ -1,0 +1,123 @@
+"""Command-line entry points: a local repl and the state audit."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+from smeggdrop.audit import audit_state
+from smeggdrop.engine import Engine, EvalRequest, Limits
+from smeggdrop.state import FileStateStore
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="smeggdrop")
+    parser.add_argument("--state", default="state", help="state directory (default: ./state)")
+    parser.add_argument("--tcl-dir", default=None, help="override bundled tcl bootstrap dir")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    repl = sub.add_parser("repl", help="evaluate tcl interactively against a state dir")
+    repl.add_argument("--nick", default="repl")
+    repl.add_argument("--channel", default="#repl")
+    repl.add_argument("--words", default=None, help="words file for [words]")
+    repl.add_argument("--time-limit", type=int, default=5)
+
+    audit = sub.add_parser("audit", help="check every saved proc: loads? runs? dead refs?")
+    audit.add_argument("--json", action="store_true", help="full report as json")
+    audit.add_argument("--no-run", action="store_true", help="skip calling zero-arg procs")
+    audit.add_argument("--time-limit", type=int, default=2, help="seconds per proc call")
+
+    args = parser.parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.WARNING,
+        format="%(levelname)s %(name)s: %(message)s",
+    )
+
+    if args.command == "repl":
+        return cmd_repl(args)
+    return cmd_audit(args)
+
+
+def cmd_repl(args) -> int:
+    try:
+        import readline  # noqa: F401  (line editing / history)
+    except ImportError:
+        pass
+
+    engine = Engine(
+        FileStateStore(args.state),
+        tcl_dir=args.tcl_dir,
+        limits=Limits(eval_time_seconds=args.time_limit),
+        words_file=args.words,
+    )
+    if engine.load_errors:
+        print(f"({len(engine.load_errors)} state entries failed to load; -v for details)")
+    print(f"smeggdrop repl — state: {args.state} — ^D to exit")
+    try:
+        while True:
+            try:
+                line = input("% ")
+            except EOFError:
+                print()
+                break
+            except KeyboardInterrupt:
+                print()
+                continue
+            if not line.strip():
+                continue
+            result = engine.eval(
+                EvalRequest(code=line, nick=args.nick, channel=args.channel, nicks=(args.nick,)),
+                say=lambda text: print(f"[say] {text}"),
+            )
+            for warning in result.warnings:
+                print(f"[warn] {warning}")
+            if result.ok:
+                if result.output:
+                    print(result.output)
+            else:
+                print(f"error: {result.output}")
+    finally:
+        engine.close()
+    return 0
+
+
+def cmd_audit(args) -> int:
+    store = FileStateStore(args.state)
+    report = audit_state(
+        store, tcl_dir=args.tcl_dir, run=not args.no_run, time_limit=args.time_limit
+    )
+
+    if args.json:
+        json.dump(report.to_dict(), sys.stdout, indent=2)
+        print()
+    else:
+        for p in report.procs:
+            if not p.loaded:
+                print(f"LOAD FAIL  {p.name}: {p.load_error}")
+            elif p.broken_refs:
+                print(f"BROKEN     {p.name}: references {', '.join(p.broken_refs)}")
+            elif p.run_ok is False:
+                print(f"RUN FAIL   {p.name}: {p.run_error}")
+            elif p.unknown_refs:
+                print(f"SUSPECT    {p.name}: unresolved {', '.join(p.unknown_refs)}")
+        for name, err in report.var_load_errors.items():
+            print(f"VAR FAIL   {name}: {err}")
+        summary = report.summary()
+        print(
+            f"\n{summary['total']} procs: "
+            f"{summary['load_failures']} load failures, "
+            f"{summary['broken_refs']} with broken refs, "
+            f"{summary['run_failures']}/{summary['ran']} run failures, "
+            f"{summary['unknown_refs']} suspect, "
+            f"{summary['var_load_failures']} var load failures"
+        )
+
+    return 1 if report.summary()["load_failures"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/smeggdrop/engine.py
+++ b/smeggdrop/engine.py
@@ -1,0 +1,249 @@
+"""Versioned Tcl evaluation: snapshot -> eval -> diff -> persist.
+
+All chat input is untrusted; the layers that deal with that here:
+
+- code runs only in the safe slave (interp.py), wall-clock limited per eval
+- context values are passed via Tcl list quoting, never interpolated
+- host builtins are capped per eval (bot_say floods, curl call count) and
+  outbound HTTP goes through security.SafeFetcher
+- results are truncated before they reach any chat platform
+- persistence is vetted: caps on change count and value size per eval, and
+  names that would corrupt the index format are refused
+
+Evals run on one dedicated worker thread: Tcl interps are thread-bound and
+the snapshot/diff persistence assumes serial evals anyway. That thread is
+also the concurrency control — platform adapters can call eval() from any
+thread and evals are serialized.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable
+
+from smeggdrop.interp import SafeTclInterp, TclError
+from smeggdrop.security import FetchError, FetchPolicy, SafeFetcher
+from smeggdrop.state import StateStore
+
+log = logging.getLogger(__name__)
+
+CATEGORIES = ("procs", "vars")
+
+
+@dataclass(frozen=True)
+class Limits:
+    eval_time_seconds: int = 5
+    result_max_chars: int = 65536
+    say_max_calls: int = 10
+    curl_max_calls: int = 5
+    curl_timeout: float = 10.0
+    curl_max_bytes: int = 1_000_000
+    max_changes_per_eval: int = 200
+    max_value_bytes: int = 1_048_576
+    max_name_chars: int = 512
+
+
+@dataclass
+class EvalRequest:
+    code: str
+    nick: str | None = None
+    channel: str | None = None
+    mask: str | None = None
+    nicks: tuple[str, ...] = ()
+
+
+@dataclass
+class EvalResult:
+    ok: bool
+    output: str
+    warnings: list[str] = field(default_factory=list)
+
+
+def diff_category(pre: dict[str, str], post: dict[str, str]) -> dict[str, str | None]:
+    """Changed entries between snapshots; None means deleted."""
+    changed: dict[str, str | None] = {}
+    for name in pre.keys() | post.keys():
+        if name.startswith("context::"):
+            continue
+        a, b = pre.get(name), post.get(name)
+        if a != b:
+            changed[name] = b
+    return changed
+
+
+class Engine:
+    def __init__(
+        self,
+        store: StateStore,
+        *,
+        tcl_dir: Path | str | None = None,
+        limits: Limits | None = None,
+        fetcher: SafeFetcher | None = None,
+        words_file: Path | str | None = None,
+    ):
+        self.store = store
+        self.limits = limits or Limits()
+        self.fetcher = fetcher or SafeFetcher(
+            FetchPolicy(timeout=self.limits.curl_timeout, max_bytes=self.limits.curl_max_bytes)
+        )
+        self.words_file = Path(words_file) if words_file else None
+        self._words: tuple[str, ...] | None = None
+        self._say: Callable[[str], None] | None = None
+        self._say_calls = 0
+        self._curl_calls = 0
+        self.load_errors: dict[str, str] = {}
+        self._closed = False
+        self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="smeggdrop-tcl")
+        self._executor.submit(self._init_interp, tcl_dir).result()
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._executor.submit(lambda: self.interp.close())
+        self._executor.shutdown(wait=True)
+
+    # -- public API ----------------------------------------------------
+
+    def eval(
+        self,
+        req: EvalRequest,
+        say: Callable[[str], None] | None = None,
+        timeout: float | None = None,
+    ) -> EvalResult:
+        """Evaluate chat-supplied code. `say` receives any core::bot_say
+        output mid-eval. Blocks until done; evals are serialized."""
+        future = self._executor.submit(self._eval, req, say)
+        return future.result(timeout if timeout is not None else self.limits.eval_time_seconds + 30)
+
+    # -- worker-thread internals ---------------------------------------
+
+    def _init_interp(self, tcl_dir) -> None:
+        self.interp = SafeTclInterp(
+            tcl_dir=tcl_dir,
+            builtins={
+                "core::print": self._b_print,
+                "core::sha1": self._b_sha1,
+                "core::curl": self._b_curl,
+                "core::bot_say": self._b_say,
+                "core::words": self._b_words,
+            },
+        )
+        for category, install in (
+            ("procs", self.interp.install_proc),
+            ("vars", self.interp.install_var),
+        ):
+            for name, payload in self.store.load(category).items():
+                try:
+                    install(name, payload)
+                except (TclError, ValueError) as e:
+                    self.load_errors[f"{category}/{name}"] = str(e)
+                    log.warning("failed to load %s %r: %s", category, name, e)
+        self.interp.alias_global_commands()
+
+    def _eval(self, req: EvalRequest, say) -> EvalResult:
+        self._say = say
+        self._say_calls = 0
+        self._curl_calls = 0
+        warnings: list[str] = []
+        try:
+            interp = self.interp
+            interp.set_context(
+                nick=req.nick,
+                mask=req.mask,
+                channel=req.channel,
+                command=req.code,
+                nicks=req.nicks,
+            )
+            interp.set_command_vars(
+                nick=req.nick, mask=req.mask, channel=req.channel, line=req.code
+            )
+            interp.eval("catch {commands::increment_eval_count}")
+
+            pre = {c: getattr(interp, c)() for c in CATEGORIES}
+            try:
+                output = interp.eval_limited(req.code, self.limits.eval_time_seconds)
+            except TclError as e:
+                return EvalResult(False, str(e))
+            post = {c: getattr(interp, c)() for c in CATEGORIES}
+
+            for category in CATEGORIES:
+                changes = diff_category(pre[category], post[category])
+                changes = self._vet_changes(category, changes, warnings)
+                if changes:
+                    self.store.save_many(category, changes)
+
+            if len(output) > self.limits.result_max_chars:
+                output = (
+                    output[: self.limits.result_max_chars]
+                    + f"\n(output truncated at {self.limits.result_max_chars} chars)"
+                )
+            return EvalResult(True, output, warnings)
+        finally:
+            self._say = None
+
+    def _vet_changes(
+        self, category: str, changes: dict[str, str | None], warnings: list[str]
+    ) -> dict[str, str | None]:
+        if len(changes) > self.limits.max_changes_per_eval:
+            warnings.append(
+                f"{category}: {len(changes)} changes exceeds the per-eval limit "
+                f"of {self.limits.max_changes_per_eval}; nothing persisted"
+            )
+            return {}
+        vetted: dict[str, str | None] = {}
+        for name, value in changes.items():
+            if (
+                len(name) > self.limits.max_name_chars
+                or any(c in name for c in "{}\\")
+                or any(c in name for c in "\n\r")
+            ):
+                warnings.append(f"{category}: not persisting unsafe name {name[:40]!r}")
+                continue
+            if value is not None and len(value.encode("utf-8")) > self.limits.max_value_bytes:
+                warnings.append(f"{category}: not persisting {name!r} (value too large)")
+                continue
+            vetted[name] = value
+        return vetted
+
+    # -- builtins exposed to the sandbox -------------------------------
+    # args arrive as strings from Tcl; raising becomes a Tcl error
+
+    def _b_print(self, *args) -> str:
+        log.info("tcl print: %s", " ".join(str(a) for a in args))
+        return ""
+
+    def _b_sha1(self, text="") -> str:
+        return hashlib.sha1(str(text).encode("utf-8")).hexdigest()
+
+    def _b_curl(self, url="") -> tuple[str, str]:
+        self._curl_calls += 1
+        if self._curl_calls > self.limits.curl_max_calls:
+            raise TclError(f"core::curl: limit of {self.limits.curl_max_calls} fetches per eval")
+        try:
+            status, body = self.fetcher.fetch(str(url))
+        except FetchError as e:
+            raise TclError(f"core::curl: {e}") from e
+        return (str(status), body)
+
+    def _b_say(self, *args) -> str:
+        self._say_calls += 1
+        if self._say_calls > self.limits.say_max_calls:
+            raise TclError(f"core::bot_say: limit of {self.limits.say_max_calls} messages per eval")
+        text = " ".join(str(a) for a in args)
+        if self._say is not None:
+            self._say(text)
+        else:
+            log.info("bot_say (no channel attached): %s", text)
+        return ""
+
+    def _b_words(self) -> tuple[str, ...]:
+        if self.words_file is None:
+            raise TclError("core::words: no words file configured")
+        if self._words is None:
+            self._words = tuple(self.words_file.read_text(encoding="utf-8").split("\n"))
+        return self._words

--- a/smeggdrop/interp.py
+++ b/smeggdrop/interp.py
@@ -1,0 +1,202 @@
+"""Safe Tcl slave interpreter on top of the stdlib tkinter binding.
+
+tkinter.Tcl() embeds a real Tcl interpreter (no Tk, no display required).
+We use it as the trusted master and evaluate all chat-supplied code in a
+`interp create -safe` slave, the same layout the perl implementation used.
+The safe slave has no exec/open/file/socket/source/etc; anything it needs
+from the outside world goes through explicitly aliased commands.
+
+Chat input is untrusted. Nothing user-controlled is ever interpolated into
+a Tcl script string here: scripts either come in whole (the code being
+evaluated, which runs inside the sandbox) or are built as Tcl lists via
+tuples, which tkinter quotes correctly.
+
+Tcl interpreters are thread-bound: create and use an instance from a single
+thread. Engine owns a dedicated worker thread for exactly this reason.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+from tkinter import Tcl, TclError
+
+__all__ = ["SafeTclInterp", "TclError"]
+
+log = logging.getLogger(__name__)
+
+DEFAULT_TCL_DIR = Path(__file__).parent / "tcl"
+BOOTSTRAP_FILES = (
+    "meta_proc.tcl",
+    "commands.tcl",
+    "meta.tcl",
+    "cache.tcl",
+    "bootstrap.tcl",
+)
+SLAVE = "smeggdrop"
+SCRIPT_VAR = "::_smeggdrop_script"
+
+
+class SafeTclInterp:
+    def __init__(self, tcl_dir: Path | str | None = None, builtins: dict | None = None):
+        # keep the Tk wrapper alive; the Tkapp on .tk is what we talk to
+        self._app = Tcl()
+        self.tk = self._app.tk
+        self.slave = SLAVE
+        self.tk.call("interp", "create", "-safe", self.slave)
+
+        tcl_dir = Path(tcl_dir) if tcl_dir else DEFAULT_TCL_DIR
+        for name in BOOTSTRAP_FILES:
+            path = tcl_dir / name
+            if path.exists():
+                self.tk.call("interp", "invokehidden", self.slave, "source", str(path))
+
+        # safe interps can't initialize `clock format` themselves (needs
+        # tzdata off disk), so run clock in the master on the slave's behalf
+        self.tk.call("interp", "alias", self.slave, "clock", "", "clock")
+
+        for name, fn in (builtins or {}).items():
+            self.register_builtin(name, fn)
+
+    def close(self) -> None:
+        try:
+            self.tk.call("interp", "delete", self.slave)
+        except TclError:
+            pass
+
+    # -- evaluation ----------------------------------------------------
+
+    def eval(self, script) -> str:
+        """Evaluate in the slave; returns the result's string rep.
+
+        `script` is either a str (a full Tcl script — only ever sandbox
+        input or trusted constants) or a tuple (one command, each element
+        quoted as a list word by tkinter — safe for untrusted values).
+        """
+        self.tk.setvar(SCRIPT_VAR, script)
+        try:
+            return self.tk.eval(f"interp eval {self.slave} ${SCRIPT_VAR}")
+        finally:
+            try:
+                self.tk.unsetvar(SCRIPT_VAR)
+            except TclError:
+                pass
+
+    def eval_limited(self, script, seconds: int) -> str:
+        """Evaluate with a wall-clock limit enforced by the master.
+
+        Slaves cannot modify their own limits, so sandboxed code can't
+        lift this.
+        """
+        deadline = int(time.time()) + max(1, int(seconds))
+        self.tk.call("interp", "limit", self.slave, "time", "-seconds", deadline)
+        try:
+            return self.eval(script)
+        finally:
+            self.tk.call("interp", "limit", self.slave, "time", "-seconds", "")
+
+    def splitlist(self, value) -> tuple[str, ...]:
+        return tuple(str(v) for v in self.tk.splitlist(value))
+
+    # -- host <-> slave plumbing ---------------------------------------
+
+    def register_builtin(self, name: str, fn) -> None:
+        """Expose a python callable to the slave as command `name`.
+
+        The callable receives its Tcl arguments as strings and may return
+        str, tuple (becomes a Tcl list) or None. Raising an exception
+        becomes a Tcl error in the sandbox.
+
+        _tkinter drops the message of exceptions raised inside command
+        callbacks, so the callback returns an (ok|err, payload) pair and a
+        master-side trampoline proc re-raises err as a real Tcl error.
+        """
+        if "::" in name:
+            ns = name.rsplit("::", 1)[0]
+            self.tk.call("namespace", "eval", ns, "")
+            self.eval(("namespace", "eval", ns, ""))
+
+        raw = "::_smeggdrop_raw_" + name.replace("::", "_")
+
+        def wrapped(*args):
+            try:
+                result = fn(*args)
+                return ("ok", "" if result is None else result)
+            except Exception as e:  # noqa: BLE001 — becomes a sandbox-side error
+                return ("err", str(e) or e.__class__.__name__)
+
+        self.tk.createcommand(raw, wrapped)
+        self.tk.call(
+            "proc",
+            name,
+            "args",
+            f"set r [uplevel #0 [linsert $args 0 {raw}]]\n"
+            'if {[lindex $r 0] eq "err"} {error [lindex $r 1]}\n'
+            "return [lindex $r 1]",
+        )
+        self.tk.call("interp", "alias", self.slave, name, "", name)
+
+    def set_context(self, **vars) -> None:
+        """Export the command context (nick, channel, ...) as context::*"""
+        self.eval(("namespace", "eval", "::context", ""))
+        for k, v in vars.items():
+            self.eval(("set", f"::context::{k}", "" if v is None else v))
+
+    def set_command_vars(self, **vars) -> None:
+        """Set namespace variables in ::commands (nick, mask, channel, line)."""
+        for k, v in vars.items():
+            self.eval(("namespace", "eval", "::commands", ("set", k, "" if v is None else v)))
+
+    def alias_global_commands(self) -> None:
+        """Alias public ::commands procs to global names (meta, cache, ...),
+        mirroring the perl loader. Runs after state load, so these win over
+        any similarly-named saved proc, same as before."""
+        try:
+            procs = self.splitlist(self.eval("namespace eval ::commands {info procs}"))
+            hidden = set(self.splitlist(self.eval("commands::get hidden_procs")))
+        except TclError:
+            return
+        for p in procs:
+            if p in hidden:
+                continue
+            self.tk.call("interp", "alias", self.slave, p, self.slave, f"::commands::{p}")
+
+    # -- state snapshot / install --------------------------------------
+    # serialization formats are byte-compatible with the perl bot:
+    #   proc: "{arglist} {body}"    var: "scalar {value}" | "array {k v ...}"
+
+    def procs(self) -> dict[str, str]:
+        out = {}
+        for name in self.splitlist(self.eval("info procs")):
+            try:
+                args = self.eval(("info", "args", name))
+                body = self.eval(("info", "body", name))
+            except TclError:
+                continue
+            out[name] = "{%s} {%s}" % (args, body)
+        return out
+
+    def vars(self) -> dict[str, str]:
+        out = {}
+        for name in self.splitlist(self.eval("info vars")):
+            try:
+                if self.eval(("array", "exists", name)) == "1":
+                    out[name] = "array {%s}" % self.eval(("array", "get", name))
+                else:
+                    out[name] = "scalar {%s}" % self.eval(("set", name))
+            except TclError:
+                continue  # declared but unset
+        return out
+
+    def install_proc(self, name: str, payload: str) -> None:
+        self.eval("proc {%s} %s" % (name, payload))
+
+    def install_var(self, name: str, payload: str) -> None:
+        kind, _, value = payload.partition(" ")
+        if kind == "scalar":
+            self.eval("set {%s} %s" % (name, value))
+        elif kind == "array":
+            self.eval("array set {%s} %s" % (name, value))
+        else:
+            raise ValueError(f"unknown var payload kind {kind!r}")

--- a/smeggdrop/platforms/__init__.py
+++ b/smeggdrop/platforms/__init__.py
@@ -1,0 +1,41 @@
+"""Chat platform adapters.
+
+The engine knows nothing about chat platforms. An adapter does three
+things: decide whether an incoming message triggers an eval (extract_code),
+build an EvalRequest with the platform's idea of nick/channel, and format
+and deliver the reply. Slack is the first adapter (issue #2); discord slots
+in beside it as a new module, not a refactor.
+"""
+
+from __future__ import annotations
+
+import re
+
+# same default the perl bot shipped: "tcl expr 1+1"
+DEFAULT_TRIGGER = re.compile(r"^\s*tcl\s")
+
+
+def extract_code(text: str, trigger: re.Pattern[str] = DEFAULT_TRIGGER) -> str | None:
+    """Return the code portion of a triggering message, or None."""
+    if text is None:
+        return None
+    match = trigger.search(text)
+    if not match:
+        return None
+    return trigger.sub("", text, count=1)
+
+
+def chunk_output(text: str, max_chunk: int, max_chunks: int) -> list[str]:
+    """Split output for platforms with message size limits; cap total chunks
+    so one eval can't flood a channel."""
+    lines: list[str] = []
+    for line in text.split("\n"):
+        while len(line) > max_chunk:
+            lines.append(line[:max_chunk])
+            line = line[max_chunk:]
+        lines.append(line)
+    if len(lines) > max_chunks:
+        total = len(lines)
+        lines = lines[: max_chunks - 1]
+        lines.append(f"error: output truncated to {max_chunks - 1} of {total} lines total")
+    return lines

--- a/smeggdrop/security.py
+++ b/smeggdrop/security.py
@@ -1,0 +1,109 @@
+"""Outbound HTTP for sandboxed code, with SSRF protections.
+
+Everything a user types in chat can reach core::curl, so the fetcher
+refuses anything that isn't plain http(s) to a public address:
+
+- scheme allowlist (http, https), no userinfo in URLs
+- every hostname is resolved and all addresses must be globally routable —
+  no loopback, RFC1918, link-local (cloud metadata), CGNAT, multicast, etc.
+- redirects are followed manually and every hop is re-validated
+- response bodies are size-capped, requests time-limited
+
+Known gap: we validate at lookup time and urllib re-resolves to connect, so
+a DNS server flipping records between the two lookups (rebinding) could
+still reach an internal address. Run the bot somewhere with no interesting
+internal network (a Lambda outside any VPC is exactly that) and this is
+moot; defense in depth, not a substitute for network isolation.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from urllib.parse import urljoin, urlsplit
+
+USER_AGENT = "smeggdrop/2 (+https://github.com/revmischa/smeggdrop)"
+REDIRECT_CODES = {301, 302, 303, 307, 308}
+
+
+class FetchError(Exception):
+    pass
+
+
+@dataclass(frozen=True)
+class FetchPolicy:
+    timeout: float = 10.0
+    max_bytes: int = 1_000_000
+    max_redirects: int = 3
+    allowed_schemes: frozenset[str] = frozenset({"http", "https"})
+    # tests and local dev only; never enable where an internal network exists
+    allow_private: bool = False
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+class SafeFetcher:
+    def __init__(self, policy: FetchPolicy | None = None):
+        self.policy = policy or FetchPolicy()
+        self._opener = urllib.request.build_opener(_NoRedirect())
+
+    def fetch(self, url: str) -> tuple[int, str]:
+        """GET a URL. Returns (status, body). Raises FetchError on refusal."""
+        for _ in range(self.policy.max_redirects + 1):
+            self.validate(url)
+            req = urllib.request.Request(
+                url, headers={"User-Agent": USER_AGENT}, method="GET"
+            )
+            try:
+                resp = self._opener.open(req, timeout=self.policy.timeout)
+            except urllib.error.HTTPError as e:
+                resp = e  # HTTPError is a usable response object
+            except (urllib.error.URLError, OSError) as e:
+                raise FetchError(f"fetch failed: {getattr(e, 'reason', e)}") from e
+            with resp:
+                status = resp.status if resp.status is not None else 0
+                if status in REDIRECT_CODES:
+                    location = resp.headers.get("Location")
+                    if not location:
+                        return status, ""
+                    url = urljoin(url, location)
+                    continue
+                body = resp.read(self.policy.max_bytes + 1)
+            if len(body) > self.policy.max_bytes:
+                body = body[: self.policy.max_bytes]
+            return status, body.decode("utf-8", "replace")
+        raise FetchError(f"too many redirects (>{self.policy.max_redirects})")
+
+    def validate(self, url: str) -> None:
+        try:
+            parts = urlsplit(url)
+        except ValueError as e:
+            raise FetchError(f"unparseable url: {e}") from e
+        if parts.scheme.lower() not in self.policy.allowed_schemes:
+            raise FetchError(f"refusing scheme {parts.scheme!r}")
+        if parts.username or parts.password:
+            raise FetchError("refusing url with credentials")
+        host = parts.hostname
+        if not host:
+            raise FetchError("no hostname in url")
+        try:
+            port = parts.port
+        except ValueError as e:
+            raise FetchError(f"bad port: {e}") from e
+        port = port or (443 if parts.scheme == "https" else 80)
+        if self.policy.allow_private:
+            return
+        try:
+            infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+        except socket.gaierror as e:
+            raise FetchError(f"cannot resolve {host!r}: {e}") from e
+        for info in infos:
+            addr = ipaddress.ip_address(info[4][0])
+            if not addr.is_global or addr.is_multicast:
+                raise FetchError(f"refusing non-public address for {host!r}")

--- a/smeggdrop/state.py
+++ b/smeggdrop/state.py
@@ -1,0 +1,102 @@
+"""File-backed state store, byte-compatible with the perl bot.
+
+Layout: <root>/{procs,vars}/_index maps names to sha1(name); each sha1-named
+file holds the serialized value. Values are opaque at this layer —
+serialization formats live in the interp layer.
+
+Names come out of the sandbox, so nothing name-derived ever becomes a file
+path: files are always named by the sha1 of the name, which also makes path
+traversal a non-issue. The engine additionally refuses to persist names
+that would corrupt the brace-delimited index format.
+
+A deleted entry is written as an empty file (what the perl bot did); loaders
+skip and clean those up.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Mapping, Protocol
+
+log = logging.getLogger(__name__)
+
+CATEGORIES = ("procs", "vars")
+INDEX_LINE = re.compile(r"^\{(.*)\}\s+([0-9a-f]{40})$")
+
+
+class StateStore(Protocol):
+    def load(self, category: str) -> dict[str, str]: ...
+
+    def save_many(self, category: str, changes: Mapping[str, str | None]) -> None: ...
+
+
+def name_sha1(name: str) -> str:
+    return hashlib.sha1(name.encode("utf-8")).hexdigest()
+
+
+class FileStateStore:
+    def __init__(self, root: Path | str):
+        self.root = Path(root)
+        self._indices: dict[str, dict[str, str]] = {}
+        for category in CATEGORIES:
+            (self.root / category).mkdir(parents=True, exist_ok=True)
+
+    def load(self, category: str) -> dict[str, str]:
+        index = self._read_index(category)
+        self._indices[category] = index
+        out: dict[str, str] = {}
+        for name, sha in index.items():
+            path = self.root / category / sha
+            try:
+                data = path.read_text(encoding="utf-8", errors="replace")
+            except FileNotFoundError:
+                log.warning("%s/%s: data file %s missing", category, name, sha)
+                continue
+            if not data:
+                # deletion marker; clean it up like the perl loader did
+                path.unlink(missing_ok=True)
+                continue
+            out[name] = data
+        return out
+
+    def save_many(self, category: str, changes: Mapping[str, str | None]) -> None:
+        index = self._indices.setdefault(category, self._read_index(category))
+        directory = self.root / category
+        for name, value in changes.items():
+            sha = name_sha1(name)
+            (directory / sha).write_text(value if value is not None else "", encoding="utf-8")
+            index[name] = sha
+        self._write_index(category, index)
+
+    def _read_index(self, category: str) -> dict[str, str]:
+        path = self.root / category / "_index"
+        if not path.exists():
+            return {}
+        index: dict[str, str] = {}
+        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            m = INDEX_LINE.match(line)
+            if m:
+                index[m.group(1)] = m.group(2)
+                continue
+            parts = line.split()
+            if len(parts) == 2:
+                index[parts[0]] = parts[1]
+            else:
+                log.warning("%s/_index: skipping malformed line %r", category, line[:80])
+        return index
+
+    def _write_index(self, category: str, index: dict[str, str]) -> None:
+        path = self.root / category / "_index"
+        tmp = path.with_suffix(".tmp")
+        tmp.write_text(
+            "".join("{%s} %s\n" % (name, index[name]) for name in sorted(index)),
+            encoding="utf-8",
+        )
+        os.replace(tmp, path)

--- a/smeggdrop/state.py
+++ b/smeggdrop/state.py
@@ -47,20 +47,29 @@ class FileStateStore:
 
     def load(self, category: str) -> dict[str, str]:
         index = self._read_index(category)
-        self._indices[category] = index
         out: dict[str, str] = {}
+        deleted: list[str] = []
         for name, sha in index.items():
             path = self.root / category / sha
             try:
                 data = path.read_text(encoding="utf-8", errors="replace")
             except FileNotFoundError:
+                # damage, not deletion — keep the entry so the loss stays
+                # visible (and recoverable if the file turns up)
                 log.warning("%s/%s: data file %s missing", category, name, sha)
                 continue
             if not data:
-                # deletion marker; clean it up like the perl loader did
+                # deletion marker: clean up the file like the perl loader
+                # did, and drop the index entry so deletes don't accumulate
                 path.unlink(missing_ok=True)
+                deleted.append(name)
                 continue
             out[name] = data
+        for name in deleted:
+            del index[name]
+        self._indices[category] = index
+        if deleted:
+            self._write_index(category, index)
         return out
 
     def save_many(self, category: str, changes: Mapping[str, str | None]) -> None:

--- a/smeggdrop/tcl/bootstrap.tcl
+++ b/smeggdrop/tcl/bootstrap.tcl
@@ -1,0 +1,18 @@
+# bootstrap for the python port: context accessors and small compat shims.
+# sourced into the safe slave before saved state is loaded, so saved procs
+# with the same names win.
+
+proc nick {} {return $context::nick}
+proc channel {} {return $context::channel}
+proc mask {} {return $context::mask}
+proc command {} {return $context::command}
+proc nicks {} {return $context::nicks}
+
+# some saved procs use [alias] to publish namespaced procs as global names
+proc alias {name target} {
+    interp alias {} $name {} $target
+}
+
+namespace eval commands {
+    proc words {} { core::words }
+}

--- a/smeggdrop/tcl/cache.tcl
+++ b/smeggdrop/tcl/cache.tcl
@@ -1,0 +1,56 @@
+namespace eval cache {
+  namespace eval buckets {
+    proc import {bucket_name {as bucket}} {
+      variable ::cache::buckets::$bucket_name
+      if ![info exists ::cache::buckets::$bucket_name] {
+        array set ::cache::buckets::$bucket_name {}
+      }
+      uplevel [list upvar ::cache::buckets::$bucket_name $as]
+    }
+  }
+  
+  proc keys bucket_name {
+    buckets::import $bucket_name
+    array names bucket
+  }
+  
+  proc exists {bucket_name key} {
+    buckets::import $bucket_name
+    info exists bucket($key)
+  }
+  
+  proc get {bucket_name key} {
+    buckets::import $bucket_name
+    ensure_key_exists $bucket_name $key
+    set bucket($key)
+  }
+
+  proc put {bucket_name key value} {
+    buckets::import $bucket_name
+    set bucket($key) $value
+  }
+
+  proc fetch {bucket_name key script} {
+    if [exists $bucket_name $key] {
+      get $bucket_name $key
+    } else {
+      put $bucket_name $key [interp_eval $script]
+    }
+  }
+  
+  proc delete {bucket_name key} {
+    buckets::import $bucket_name
+    ensure_key_exists $bucket_name $key
+    unset bucket($key)
+  }
+
+  proc ensure_key_exists {bucket_name key} {
+    if ![exists $bucket_name $key] {
+      error "bucket \"$bucket_name\" doesn't have key \"$key\""
+    }
+  }
+}
+
+namespace eval commands {
+  meta_proc cache "delete" "exists" "fetch" "get" "keys" "put"
+}

--- a/smeggdrop/tcl/commands.tcl
+++ b/smeggdrop/tcl/commands.tcl
@@ -1,0 +1,36 @@
+namespace eval commands {
+  variable nick
+  variable mask
+  variable hand
+  variable channel
+  variable line
+  variable eval_count -1
+  variable hidden_procs hidden
+  
+  proc hidden {proc name args body} {
+    variable hidden_procs
+    uplevel [list proc $name $args $body]
+    lappend hidden_procs $name
+  }
+  
+  hidden proc configure args {
+    foreach var $args {
+      variable $var
+      set $var [uplevel [list set $var]]
+    }
+  }
+
+  hidden proc increment_eval_count {} {
+    variable eval_count
+    incr eval_count
+  }
+  
+  hidden proc get var {
+    variable $var
+    set $var
+  }
+  
+  hidden proc apply {command arguments} {
+    uplevel [concat $command $arguments]
+  }
+}

--- a/smeggdrop/tcl/meta.tcl
+++ b/smeggdrop/tcl/meta.tcl
@@ -1,0 +1,17 @@
+namespace eval meta {
+  proc eval_count {} {
+    commands::get eval_count
+  }
+  
+  proc line {} {
+    commands::get line
+  }
+  
+  proc uptime {} {
+    $::versioned_interpreter uptime
+  }
+}
+
+namespace eval commands {
+  meta_proc meta
+}

--- a/smeggdrop/tcl/meta_proc.tcl
+++ b/smeggdrop/tcl/meta_proc.tcl
@@ -1,0 +1,38 @@
+namespace eval meta_proc {
+  proc call {namespace name arguments commands} {
+    set command [lindex $arguments 0]
+    set arguments [lrange $arguments 1 end]    
+#    if ![llength $commands] {
+      set commands [lsort [namespace eval ::$namespace {info procs}]]
+#    }
+    
+    set usage [join [concat [lrange $commands 0 end-1] [list "or [lindex $commands end]"]] ", "]
+    set matches [lsearch -all -inline -glob $commands $command*]
+    
+    if {$command eq ""} {
+      error "wrong # args: should be \"$name command ?arg arg ...?\""
+    } elseif {[llength $matches] == 0} {
+      error "bad command \"$command\": must be $usage"
+    } elseif {[llength $matches] > 1} {
+      error "ambiguous command \"$command\": must be $usage"
+    } else {
+      set code [catch [concat [list ::${namespace}::[lindex $matches 0]] $arguments] result]
+      if {$code && [regexp {^wrong # args} $result]} {
+        error [string map [list ::${namespace}:: "$name "] $result]
+      } else {
+        return -code $code $result
+      }
+    }
+  }
+}
+
+proc meta_proc {name args} {
+  if {[lindex $args 0] eq "-namespace"} {
+    set namespace [lindex $args 1]
+    set args [lrange $args 2 end]
+  } else {
+    set namespace $name
+  }
+  
+  uplevel [list proc $name args "meta_proc::call [list $namespace] [list $name] \$args [list $args]"]
+}

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,89 @@
+import json
+
+import pytest
+
+from smeggdrop.audit import audit_state
+from smeggdrop.state import FileStateStore
+
+
+@pytest.fixture
+def store(tmp_path):
+    s = FileStateStore(tmp_path)
+    s.save_many(
+        "procs",
+        {
+            "good": "{} {return good}",
+            "needs_exec": "{} {exec ls /}",
+            "mystery": "{} {frobnicate 1 2}",
+            "with_args": "{a b} {expr {$a + $b}}",
+            "defaulted": '{{who world}} {return "hi $who"}',
+            "wont_load": "{} {return {unbalanced",
+        },
+    )
+    s.save_many("vars", {"ok_var": "scalar {1}", "bad_var": "bogus {1}"})
+    return s
+
+
+def by_name(report):
+    return {p.name: p for p in report.procs}
+
+
+def test_audit_full_report(store):
+    report = audit_state(store)
+    procs = by_name(report)
+
+    assert procs["good"].loaded and procs["good"].ran and procs["good"].run_ok
+    assert procs["good"].healthy
+
+    assert "exec" in procs["needs_exec"].broken_refs
+    assert procs["needs_exec"].run_ok is False
+    assert not procs["needs_exec"].healthy
+
+    assert "frobnicate" in procs["mystery"].unknown_refs
+    assert procs["mystery"].run_ok is False
+
+    # can't be called safely without args: static checks only
+    assert procs["with_args"].loaded and not procs["with_args"].ran
+
+    # all args have defaults, so it runs
+    assert procs["defaulted"].ran and procs["defaulted"].run_ok
+
+    assert not procs["wont_load"].loaded
+    assert procs["wont_load"].load_error
+
+    assert "bad_var" in report.var_load_errors
+    assert "ok_var" not in report.var_load_errors
+
+
+def test_audit_summary_counts(store):
+    report = audit_state(store)
+    summary = report.summary()
+    assert summary["total"] == 6
+    assert summary["load_failures"] == 1
+    assert summary["broken_refs"] == 1
+    assert summary["run_failures"] == 2
+    assert summary["var_load_failures"] == 1
+
+
+def test_audit_no_run(store):
+    report = audit_state(store, run=False)
+    assert not any(p.ran for p in report.procs)
+
+
+def test_audit_report_is_json_serializable(store):
+    json.dumps(audit_state(store).to_dict())
+
+
+def test_audit_never_writes_state(store, tmp_path):
+    before = {
+        p.name: p.read_bytes()
+        for p in tmp_path.rglob("*")
+        if p.is_file()
+    }
+    audit_state(store)
+    after = {
+        p.name: p.read_bytes()
+        for p in tmp_path.rglob("*")
+        if p.is_file()
+    }
+    assert before == after

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,175 @@
+import pytest
+
+from smeggdrop.engine import Engine, EvalRequest, Limits
+from smeggdrop.state import FileStateStore
+
+
+@pytest.fixture
+def store(tmp_path):
+    return FileStateStore(tmp_path)
+
+
+@pytest.fixture
+def engine(store):
+    e = Engine(store, limits=Limits(eval_time_seconds=2))
+    yield e
+    e.close()
+
+
+def run(engine, code, **kw):
+    return engine.eval(EvalRequest(code=code, nick="tester", channel="#test", **kw))
+
+
+def test_basic_eval(engine):
+    result = run(engine, "expr {6 * 7}")
+    assert result.ok
+    assert result.output == "42"
+
+
+def test_error_result(engine):
+    result = run(engine, "nonexistent-command")
+    assert not result.ok
+    assert "nonexistent-command" in result.output
+
+
+def test_procs_persist_across_engines(store, engine):
+    assert run(engine, "proc triple x {expr {$x * 3}}").ok
+    engine.close()
+
+    second = Engine(store, limits=Limits(eval_time_seconds=2))
+    try:
+        assert run(second, "triple 5").output == "15"
+    finally:
+        second.close()
+
+
+def test_vars_persist_and_unset_deletes(store, engine):
+    assert run(engine, "set counter 41").ok
+    assert run(engine, "array set prefs {color red}").ok
+    assert run(engine, "incr counter").output == "42"
+    engine.close()
+
+    second = Engine(store, limits=Limits(eval_time_seconds=2))
+    try:
+        assert run(second, "set counter").output == "42"
+        assert run(second, "set prefs(color)").output == "red"
+        assert run(second, "unset counter").ok
+    finally:
+        second.close()
+
+    third = Engine(store, limits=Limits(eval_time_seconds=2))
+    try:
+        assert not run(third, "set counter").ok
+    finally:
+        third.close()
+
+
+def test_context_reaches_sandbox(engine):
+    assert run(engine, "nick").output == "tester"
+    assert run(engine, "channel").output == "#test"
+
+
+def test_meta_alias_present(engine):
+    # eval_count increments per eval; just needs to be an integer
+    int(run(engine, "meta eval_count").output)
+
+
+def test_say_callback_and_flood_cap(store):
+    engine = Engine(store, limits=Limits(eval_time_seconds=2, say_max_calls=3))
+    said = []
+    try:
+        result = engine.eval(
+            EvalRequest(code="for {set i 0} {$i < 10} {incr i} {core::bot_say hi $i}"),
+            say=said.append,
+        )
+        assert not result.ok
+        assert "limit" in result.output
+        assert len(said) == 3
+    finally:
+        engine.close()
+
+
+def test_output_truncated(store):
+    engine = Engine(store, limits=Limits(eval_time_seconds=2, result_max_chars=100))
+    try:
+        result = run(engine, "string repeat a 10000")
+        assert result.ok
+        assert len(result.output) < 200
+        assert "truncated" in result.output
+    finally:
+        engine.close()
+
+
+def test_runaway_eval_times_out_and_engine_survives(engine):
+    result = run(engine, "while 1 {}")
+    assert not result.ok
+    assert run(engine, "expr {1 + 1}").output == "2"
+
+
+def test_mass_change_not_persisted(store):
+    engine = Engine(store, limits=Limits(eval_time_seconds=2, max_changes_per_eval=5))
+    try:
+        result = run(engine, "for {set i 0} {$i < 50} {incr i} {set spam_$i x}")
+        assert result.ok
+        assert result.warnings
+    finally:
+        engine.close()
+
+    fresh = FileStateStore(store.root)
+    assert fresh.load("vars") == {}
+
+
+def test_unsafe_names_not_persisted(store, engine):
+    result = run(engine, r'proc {bad{name} {x} {sha}} {} {return 1}')
+    assert result.ok
+    assert any("unsafe name" in w for w in result.warnings)
+    engine.close()
+    assert FileStateStore(store.root).load("procs") == {}
+
+
+def test_oversized_value_not_persisted(store):
+    engine = Engine(store, limits=Limits(eval_time_seconds=2, max_value_bytes=100))
+    try:
+        result = run(engine, "set big [string repeat a 1000]")
+        assert result.ok
+        assert any("too large" in w for w in result.warnings)
+    finally:
+        engine.close()
+    assert FileStateStore(store.root).load("vars") == {}
+
+
+def test_curl_call_cap(store):
+    class CountingFetcher:
+        calls = 0
+
+        def fetch(self, url):
+            CountingFetcher.calls += 1
+            return 200, "ok"
+
+    engine = Engine(store, limits=Limits(eval_time_seconds=2, curl_max_calls=2),
+                    fetcher=CountingFetcher())
+    try:
+        result = run(engine, "for {set i 0} {$i < 5} {incr i} {core::curl http://example.com/}")
+        assert not result.ok
+        assert "limit" in result.output
+        assert CountingFetcher.calls == 2
+    finally:
+        engine.close()
+
+
+def test_legacy_state_dir_loads(tmp_path):
+    import hashlib
+
+    procs = tmp_path / "procs"
+    procs.mkdir()
+    sha = hashlib.sha1(b"greet").hexdigest()
+    (procs / "_index").write_text("{greet} %s\n" % sha)
+    (procs / sha).write_text('{name} {return "hello $name"}')
+    (tmp_path / "vars").mkdir()
+
+    engine = Engine(FileStateStore(tmp_path), limits=Limits(eval_time_seconds=2))
+    try:
+        assert engine.load_errors == {}
+        assert run(engine, "greet world").output == "hello world"
+    finally:
+        engine.close()

--- a/tests/test_interp.py
+++ b/tests/test_interp.py
@@ -1,0 +1,104 @@
+import pytest
+
+from smeggdrop.interp import SafeTclInterp, TclError
+
+
+@pytest.fixture
+def interp():
+    i = SafeTclInterp()
+    yield i
+    i.close()
+
+
+def test_basic_eval(interp):
+    assert interp.eval("expr {1 + 1}") == "2"
+
+
+def test_error_raises(interp):
+    with pytest.raises(TclError):
+        interp.eval("this-command-does-not-exist")
+
+
+@pytest.mark.parametrize(
+    "script",
+    [
+        "open /etc/passwd",
+        "exec ls",
+        "file exists /",
+        "socket localhost 80",
+        "glob *",
+        "exit 0",
+    ],
+)
+def test_dangerous_commands_hidden(interp, script):
+    with pytest.raises(TclError):
+        interp.eval(script)
+
+
+def test_clock_aliased_from_master(interp):
+    assert "1970" in interp.eval("clock format 0 -gmt 1")
+
+
+def test_tuple_args_are_injection_safe(interp):
+    hostile = 'a [exec ls] {b} $env(PATH) "; exit'
+    interp.eval(("set", "x", hostile))
+    assert interp.eval(("set", "x")) == hostile
+
+
+def test_context_vars_and_accessors(interp):
+    interp.set_context(nick="alice", channel="#chan", mask="a@b", command="cmd", nicks=("alice", "bob"))
+    assert interp.eval("nick") == "alice"
+    assert interp.eval("channel") == "#chan"
+    assert interp.eval("set context::nick") == "alice"
+    assert interp.splitlist(interp.eval("nicks")) == ("alice", "bob")
+
+
+def test_alias_compat_proc(interp):
+    interp.eval("proc greet {} {return hi}")
+    interp.eval("alias hello ::greet")
+    assert interp.eval("hello") == "hi"
+
+
+def test_time_limit_fires_and_interp_survives(interp):
+    with pytest.raises(TclError):
+        interp.eval_limited("while 1 {}", 1)
+    assert interp.eval("expr {2 + 2}") == "4"
+
+
+def test_slave_cannot_lift_its_own_limit(interp):
+    with pytest.raises(TclError):
+        interp.eval_limited(
+            "interp limit {} time -seconds {}; while 1 {}", 1
+        )
+
+
+def test_snapshot_serialization_roundtrip(interp):
+    interp.eval("proc double x {expr {$x * 2}}")
+    interp.eval("set scalar_var {hello world}")
+    interp.eval("array set arr {a 1 b 2}")
+
+    procs = interp.procs()
+    vars_ = interp.vars()
+    assert procs["double"] == "{x} {expr {$x * 2}}"
+    assert vars_["scalar_var"] == "scalar {hello world}"
+    assert vars_["arr"].startswith("array {")
+
+    other = SafeTclInterp()
+    try:
+        other.install_proc("double", procs["double"])
+        other.install_var("scalar_var", vars_["scalar_var"])
+        other.install_var("arr", vars_["arr"])
+        assert other.eval("double 21") == "42"
+        assert other.eval("set scalar_var") == "hello world"
+        assert other.eval("set arr(b)") == "2"
+    finally:
+        other.close()
+
+
+def test_commands_namespace_aliased_globally(interp):
+    interp.alias_global_commands()
+    # meta comes from meta.tcl via meta_proc; eval_count starts at -1
+    assert interp.eval("meta eval_count") == "-1"
+    # hidden procs must not be aliased
+    with pytest.raises(TclError):
+        interp.eval("get eval_count")

--- a/tests/test_platforms.py
+++ b/tests/test_platforms.py
@@ -1,0 +1,32 @@
+import re
+
+from smeggdrop.platforms import DEFAULT_TRIGGER, chunk_output, extract_code
+
+
+def test_extract_code_default_trigger():
+    assert extract_code("tcl expr {1 + 1}") == "expr {1 + 1}"
+    assert extract_code("  tcl set x 1") == "set x 1"
+    assert extract_code("nothing to see") is None
+    assert extract_code("tclnope") is None
+
+
+def test_extract_code_custom_trigger():
+    trigger = re.compile(r"^!eval\s+")
+    assert extract_code("!eval puts hi", trigger) == "puts hi"
+    assert extract_code("tcl puts hi", trigger) is None
+
+
+def test_chunk_output_splits_long_lines():
+    chunks = chunk_output("a" * 25, max_chunk=10, max_chunks=20)
+    assert chunks == ["a" * 10, "a" * 10, "a" * 5]
+
+
+def test_chunk_output_caps_total_chunks():
+    text = "\n".join(str(i) for i in range(100))
+    chunks = chunk_output(text, max_chunk=100, max_chunks=5)
+    assert len(chunks) == 5
+    assert "truncated" in chunks[-1]
+
+
+def test_default_trigger_matches_perl_config():
+    assert DEFAULT_TRIGGER.pattern == r"^\s*tcl\s"

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,106 @@
+import http.server
+import threading
+
+import pytest
+
+from smeggdrop.security import FetchError, FetchPolicy, SafeFetcher
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "ftp://example.com/file",
+        "file:///etc/passwd",
+        "gopher://example.com/",
+        "http://user:pass@example.com/",
+        "http://127.0.0.1/",
+        "http://[::1]/",
+        "http://10.0.0.1/",
+        "http://192.168.1.1/",
+        "http://169.254.169.254/latest/meta-data/",
+        "http://100.64.0.1/",
+        "http://0.0.0.0/",
+        "http://localhost/",
+    ],
+)
+def test_validate_refuses(url):
+    with pytest.raises(FetchError):
+        SafeFetcher().validate(url)
+
+
+def test_validate_allows_public_literal():
+    SafeFetcher().validate("http://8.8.8.8/")
+    SafeFetcher().validate("https://1.1.1.1/x?y=z")
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/hello":
+            body = b"hello world"
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        elif self.path == "/redirect":
+            self.send_response(302)
+            self.send_header("Location", "/hello")
+            self.end_headers()
+        elif self.path == "/loop":
+            self.send_response(302)
+            self.send_header("Location", "/loop")
+            self.end_headers()
+        elif self.path == "/big":
+            body = b"x" * 5000
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, *args):
+        pass
+
+
+@pytest.fixture(scope="module")
+def server():
+    httpd = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    yield f"http://127.0.0.1:{httpd.server_port}"
+    httpd.shutdown()
+
+
+@pytest.fixture
+def fetcher():
+    # allow_private so tests can hit the local server; production default is off
+    return SafeFetcher(FetchPolicy(allow_private=True, max_bytes=1000, max_redirects=2, timeout=5))
+
+
+def test_fetch_ok(server, fetcher):
+    status, body = fetcher.fetch(server + "/hello")
+    assert status == 200
+    assert body == "hello world"
+
+
+def test_fetch_follows_redirect(server, fetcher):
+    status, body = fetcher.fetch(server + "/redirect")
+    assert status == 200
+    assert body == "hello world"
+
+
+def test_fetch_redirect_loop_capped(server, fetcher):
+    with pytest.raises(FetchError, match="redirect"):
+        fetcher.fetch(server + "/loop")
+
+
+def test_fetch_body_capped(server, fetcher):
+    status, body = fetcher.fetch(server + "/big")
+    assert status == 200
+    assert len(body) == 1000
+
+
+def test_fetch_non_2xx_returned_not_raised(server, fetcher):
+    status, _ = fetcher.fetch(server + "/nope")
+    assert status == 404

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -30,15 +30,33 @@ def test_legacy_perl_layout_loads(tmp_path):
 
 def test_deletion_writes_empty_file_and_skips_on_load(tmp_path):
     store = FileStateStore(tmp_path)
-    store.save_many("vars", {"x": "scalar {1}"})
+    store.save_many("vars", {"x": "scalar {1}", "keep": "scalar {2}"})
     store.save_many("vars", {"x": None})
 
     sha = name_sha1("x")
     assert (tmp_path / "vars" / sha).read_text() == ""
     fresh = FileStateStore(tmp_path)
-    assert fresh.load("vars") == {}
-    # loader cleans up the marker file like the perl one did
+    assert fresh.load("vars") == {"keep": "scalar {2}"}
+    # loader cleans up the marker file like the perl one did, and prunes
+    # the index entry so deletions don't accumulate
     assert not (tmp_path / "vars" / sha).exists()
+    assert "{x}" not in (tmp_path / "vars" / "_index").read_text()
+
+    # a save after the pruned load must not resurrect the entry
+    fresh.save_many("vars", {"other": "scalar {3}"})
+    third = FileStateStore(tmp_path)
+    assert third.load("vars") == {"keep": "scalar {2}", "other": "scalar {3}"}
+
+
+def test_missing_data_file_keeps_index_entry(tmp_path):
+    # damage (file gone, no deletion marker) must stay visible, not be pruned
+    store = FileStateStore(tmp_path)
+    store.save_many("procs", {"lost": "{} {return x}"})
+    (tmp_path / "procs" / name_sha1("lost")).unlink()
+
+    fresh = FileStateStore(tmp_path)
+    assert fresh.load("procs") == {}
+    assert "{lost}" in (tmp_path / "procs" / "_index").read_text()
 
 
 def test_malformed_index_lines_skipped(tmp_path):

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,63 @@
+import hashlib
+
+from smeggdrop.state import FileStateStore, name_sha1
+
+
+def test_roundtrip(tmp_path):
+    store = FileStateStore(tmp_path)
+    store.save_many("procs", {"greet": "{name} {return hi}"})
+    store.save_many("vars", {"x": "scalar {1}"})
+
+    fresh = FileStateStore(tmp_path)
+    assert fresh.load("procs") == {"greet": "{name} {return hi}"}
+    assert fresh.load("vars") == {"x": "scalar {1}"}
+
+
+def test_legacy_perl_layout_loads(tmp_path):
+    # exactly what the perl bot writes: {name} sha1 per index line,
+    # sha1-of-name data files
+    procs = tmp_path / "procs"
+    procs.mkdir(parents=True)
+    name = "greet"
+    sha = hashlib.sha1(name.encode()).hexdigest()
+    (procs / "_index").write_text("{%s} %s\n" % (name, sha))
+    (procs / sha).write_text('{name} {return "hello $name"}')
+    (tmp_path / "vars").mkdir()
+
+    store = FileStateStore(tmp_path)
+    assert store.load("procs") == {name: '{name} {return "hello $name"}'}
+
+
+def test_deletion_writes_empty_file_and_skips_on_load(tmp_path):
+    store = FileStateStore(tmp_path)
+    store.save_many("vars", {"x": "scalar {1}"})
+    store.save_many("vars", {"x": None})
+
+    sha = name_sha1("x")
+    assert (tmp_path / "vars" / sha).read_text() == ""
+    fresh = FileStateStore(tmp_path)
+    assert fresh.load("vars") == {}
+    # loader cleans up the marker file like the perl one did
+    assert not (tmp_path / "vars" / sha).exists()
+
+
+def test_malformed_index_lines_skipped(tmp_path):
+    vars_dir = tmp_path / "vars"
+    vars_dir.mkdir(parents=True)
+    sha = name_sha1("ok")
+    (vars_dir / "_index").write_text(
+        "garbage with several words here\n{ok} %s\n\n" % sha
+    )
+    (vars_dir / sha).write_text("scalar {fine}")
+    store = FileStateStore(tmp_path)
+    assert store.load("vars") == {"ok": "scalar {fine}"}
+
+
+def test_names_never_become_paths(tmp_path):
+    store = FileStateStore(tmp_path)
+    evil = "../../escape"
+    store.save_many("procs", {evil: "{} {return x}"})
+    # data lands under procs/ named by sha1, not by the name
+    assert (tmp_path / "procs" / name_sha1(evil)).exists()
+    assert not (tmp_path.parent / "escape").exists()
+    assert FileStateStore(tmp_path).load("procs") == {evil: "{} {return x}"}

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,107 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "slack-bolt"
+version = "1.30.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "slack-sdk" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/4f/5ba15533d66da2e7174334cc0e2805142e5390c9f4c5f31633df78b17006/slack_bolt-1.30.0.tar.gz", hash = "sha256:af38258d41f801ad9c74503090e0f39accd66c49f667f7e55c97fcdb0e51b886", size = 131180, upload-time = "2026-07-15T20:47:33.679Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/ee/1a7a286cf98fa3f4eeffaabc090e82f58f058ab4812aa1d7421d92c2637a/slack_bolt-1.30.0-py2.py3-none-any.whl", hash = "sha256:81f5bc46e79516d23d5e2a31dded6304dd1b8b6b72c0083f2f31d5d801e262c4", size = 235341, upload-time = "2026-07-15T20:47:32.113Z" },
+]
+
+[[package]]
+name = "slack-sdk"
+version = "3.43.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/75/a4964eb771a0c74d79ee7a3bee6fb5d9718909dd1b675e80d62a6a0ad90a/slack_sdk-3.43.0.tar.gz", hash = "sha256:0553152e46c4259eb69f7464cdadc35ba4802ca10f9f5a849c92cf03d6c2ba07", size = 252769, upload-time = "2026-06-30T18:04:41.59Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/55/42141b8338d46323d5b3c6095201b044c670c20f898643b322ea9b1543a1/slack_sdk-3.43.0-py2.py3-none-any.whl", hash = "sha256:4b6557c65577fc172f685af218b811f9f3b4909e24cddd839ada09565f10c585", size = 315866, upload-time = "2026-06-30T18:04:39.636Z" },
+]
+
+[[package]]
+name = "smeggdrop"
+version = "0.1.0"
+source = { editable = "." }
+
+[package.optional-dependencies]
+slack = [
+    { name = "slack-bolt" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "slack-bolt", marker = "extra == 'slack'", specifier = ">=1.20" }]
+provides-extras = ["slack"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8" }]


### PR DESCRIPTION
First chunk of #2: the versioned Tcl interpreter, ported off perl.

User code runs in an `interp create -safe` slave on the stdlib tkinter binding — real Tcl 8.6, no Tk, no native extensions. The perl `tcl/` bootstrap (commands, meta_proc, cache) is sourced unchanged, and the state format is byte-compatible (sha1-named proc/var files + `_index`), so an existing state dir loads as-is.

Chat input is untrusted by design, so containment is layered: per-eval wall-clock limits the slave can't lift, context passed as quoted list words (no string interpolation), `core::curl` refuses non-public addresses and re-validates redirects, per-eval caps on bot_say/curl calls, output size, and persisted change count/size. Details in the README security section.

`smeggdrop audit` is the verification loop for the port: loads a state dir into a throwaway sandbox, flags procs that fail to load or reference commands that no longer exist (safe-interp hidden, tclcurl-era), and calls everything that's callable without args. `--json` for machine-readable output.

`smeggdrop repl` evaluates against a state dir locally with no chat platform.

63 tests, including legacy-layout fixtures and SSRF/limit coverage. Slack adapter (Socket Mode + Events API/Lambda) is the next PR.