### PR TITLE
Slack adapter: Socket Mode + Events API on Lambda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 dist/
 state-local*/
 state/
+.env

--- a/Dockerfile.lambda
+++ b/Dockerfile.lambda
@@ -1,0 +1,28 @@
+# container image for the slack adapter on AWS Lambda
+#
+#   docker build -f Dockerfile.lambda -t smeggdrop-lambda .
+#   # push to ECR, create the function from the image, then set:
+#   #   SLACK_BOT_TOKEN, SLACK_SIGNING_SECRET, SMEGGDROP_* (see README)
+#
+# reserved concurrency should be 1 (evals are serialized by design) and the
+# function role needs lambda:InvokeFunction on itself for bolt's lazy
+# listeners.
+
+FROM public.ecr.aws/docker/library/python:3.13-slim
+
+# tkinter needs the tcl/tk shared libraries at runtime
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libtcl8.6 libtk8.6 \
+    && rm -rf /var/lib/apt/lists/* \
+    && python -c "import tkinter; print(tkinter.Tcl().eval('info patchlevel'))"
+
+WORKDIR /app
+COPY pyproject.toml README.md ./
+COPY smeggdrop ./smeggdrop
+RUN pip install --no-cache-dir ".[lambda]" awslambdaric
+
+# ephemeral unless EFS is mounted here; S3 store is planned (issue #2)
+ENV SMEGGDROP_STATE=/tmp/state
+
+ENTRYPOINT ["python", "-m", "awslambdaric"]
+CMD ["smeggdrop.lambda_handler.handler"]

--- a/README.md
+++ b/README.md
@@ -90,17 +90,18 @@ required argument so the whole library gets exercised rather than just the
 zero-argument part, and sorts "wanted a number, got `test`" into its own
 bucket instead of counting it as breakage. Fix, re-run, repeat.
 
-Against the hardchats state (6,604 procs accumulated 2007-2017):
+Against the hardchats state (6,603 procs accumulated 2007-2017):
 
 | | procs |
 |---|---|
-| ran clean | 5,148 |
-| reached the network (stubbed in audit) | 690 |
-| failed | 516 |
-| wanted different arguments | 249 |
+| ran clean | 5,256 |
+| reached the network (stubbed in audit) | 729 |
+| failed | 346 |
+| wanted different arguments than the audit passes | 233 |
+| timed out | 38 |
 | failed to load | 0 |
 
-So ~88% demonstrably work. Nearly all remaining failures are data rot
+So ~91% demonstrably work. Nearly all remaining failures are data rot
 rather than port breakage: helpers their authors deleted years ago,
 services that no longer resolve (`i.buttes.org`, `magick.buttes.org`), and
 a few deliberate infinite loops.

--- a/README.md
+++ b/README.md
@@ -38,13 +38,28 @@ Create a Slack app with bot scopes `chat:write`, `users:read`,
 subscribe to the `message.channels` (and `message.groups`) events. Then
 say `tcl expr {6 * 7}` in a channel the bot is in.
 
+[`slack-app-manifest.yml`](slack-app-manifest.yml) has all of that ready
+to paste into *Create New App → From an app manifest*.
+
 Local development uses Socket Mode (no public endpoint; enable it in the
-app config and mint an `xapp-` token):
+app config and mint an `xapp-` token with `connections:write`). Put the
+credentials in `.env` (gitignored) and use the dev script:
 
 ```sh
-export SLACK_BOT_TOKEN=xoxb-... SLACK_APP_TOKEN=xapp-...
-uv run --extra slack smeggdrop --state state-local slack
+cat > .env <<'EOF'
+SLACK_BOT_TOKEN=xoxb-...
+SLACK_APP_TOKEN=xapp-...
+EOF
+
+./run-slack-dev.sh state-local          # or any state dir
 ```
+
+Slack-specific behaviour worth knowing: mentions are resolved to plain
+nicks on the way in, so procs written for irc see `deathto winkie` rather
+than `deathto <@U03S5JZ7U>`; mIRC colour codes are stripped from replies
+(Slack renders none of them, and the digits would litter the ascii art);
+and `[channel]` reports `#name`, not the channel id, because saved procs
+print it and key cache buckets off it.
 
 Production runs the Events API on Lambda from a container image
 ([`Dockerfile.lambda`](Dockerfile.lambda)):
@@ -59,9 +74,13 @@ Production runs the Events API on Lambda from a container image
 
 Config env vars: `SMEGGDROP_TRIGGER` (default `^\s*tcl\s`),
 `SMEGGDROP_CHANNELS` (comma-separated channel IDs, empty = all),
-`SMEGGDROP_STATE`, `SMEGGDROP_TIME_LIMIT`, `SMEGGDROP_WORDS`.
-Retried Slack deliveries are dropped rather than re-evaluated, and request
-signatures are verified by bolt.
+`SMEGGDROP_STATE`, `SMEGGDROP_TIME_LIMIT`, `SMEGGDROP_WORDS`,
+`SMEGGDROP_MEMORY_MB` (default 2048, 0 disables).
+
+Request signatures are verified by bolt. Retried deliveries are dropped
+rather than re-evaluated — running someone's code twice is worse than
+missing it — which does mean a message sent while the bot is restarting is
+lost rather than executed late.
 
 `audit` exists so the port can be verified against real accumulated state:
 it loads everything into a throwaway sandbox (nothing persisted, network
@@ -89,12 +108,29 @@ so containment is layered:
 - persistence is vetted: per-eval caps on change count and value size, and
   names that would corrupt the index format are refused (state files are
   named by sha1, so names never become paths)
+- the process address space is capped (`SMEGGDROP_MEMORY_MB`, default 2 GB).
+  Tcl has no per-interp memory limit and a single command —
+  `string repeat x 40000000000` — outruns both the clock and any command
+  counter, so this is what stops one eval from taking the host down with
+  it. The bot dies and restarts instead; state is on disk, restarts are
+  cheap.
+- outgoing text has Slack mention syntax defanged and posts with
+  `parse=none`, so the bot can't be driven as an `@channel` ping cannon
 
-Residual risks worth knowing: DNS rebinding can slip past the fetcher's
-resolve-time checks (run the bot with no reachable internal network — a
-Lambda outside any VPC — and it's moot), and Tcl has no per-interp memory
-cap (a hostile eval can balloon the process; process-level limits are the
-backstop).
+`tests/test_sandbox_escape.py` is the adversarial suite: token theft via
+`::env`, filesystem reads, LAN and cloud-metadata SSRF, nested-interp
+escapes, limit lifting, `exit`, path traversal, flooding.
+
+Two notes on limits, both learned the hard way. Tcl's `interp limit
+... command` counter is **cumulative for the interpreter's lifetime**, not
+per-eval, so a fixed ceiling is permanently tripped by the first runaway
+loop and every later eval fails — one `while 1 {}` becomes a channel-wide
+denial of service. The wall-clock limit is checked at the same granularity
+and resets per eval, so that is the one to rely on.
+
+Residual risk worth knowing: DNS rebinding can slip past the fetcher's
+resolve-time checks. Run the bot somewhere with no reachable internal
+network (a Lambda outside any VPC) and it's moot.
 
 ## Architecture
 
@@ -104,6 +140,7 @@ smeggdrop/
   engine.py     versioned eval: snapshot -> eval -> diff -> persist
   state.py      file store, byte-compatible with the perl layout
   security.py   SSRF-guarded fetcher behind core::curl
+  hardening.py  process-level containment (address space cap)
   audit.py      state verification (the `audit` subcommand)
   platforms/    adapters; the engine never imports platform SDKs
   tcl/          bootstrap sourced into the slave (from the perl tree)

--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ rather than port breakage: helpers their authors deleted years ago,
 services that no longer resolve (`i.buttes.org`, `magick.buttes.org`), and
 a few deliberate infinite loops.
 
+The failure count is also pessimistic in a way that can't be automated
+away: plenty of procs raise on purpose, because the error message is the
+joke — `ncock 24` answers "COCK SIZE OFF THE CHARTS", and a handful more
+refuse with `please see a dentist for further assistance`. Those are
+working procs that the audit has no way to tell apart from broken ones.
+
 ## Security model
 
 All chat input is untrusted and gets evaluated anyway — that's the product —

--- a/README.md
+++ b/README.md
@@ -31,6 +31,38 @@ The state directory format is unchanged from the perl bot (sha1-named
 proc/var files plus an `_index` per category), so an existing state dir
 works as-is.
 
+## Slack
+
+Create a Slack app with bot scopes `chat:write`, `users:read`,
+`channels:history` (plus `groups:history` for private channels) and
+subscribe to the `message.channels` (and `message.groups`) events. Then
+say `tcl expr {6 * 7}` in a channel the bot is in.
+
+Local development uses Socket Mode (no public endpoint; enable it in the
+app config and mint an `xapp-` token):
+
+```sh
+export SLACK_BOT_TOKEN=xoxb-... SLACK_APP_TOKEN=xapp-...
+uv run --extra slack smeggdrop --state state-local slack
+```
+
+Production runs the Events API on Lambda from a container image
+([`Dockerfile.lambda`](Dockerfile.lambda)):
+
+- point the app's event request URL at the function URL / API Gateway;
+  set `SLACK_BOT_TOKEN` and `SLACK_SIGNING_SECRET` on the function
+- set **reserved concurrency to 1** — evals are serialized by design
+- grant the function role `lambda:InvokeFunction` on itself (bolt's lazy
+  listeners ack within Slack's 3s window, then re-invoke to run the eval)
+- state is ephemeral per warm container until the S3 store lands; mount
+  EFS at `SMEGGDROP_STATE` if you need durability before then
+
+Config env vars: `SMEGGDROP_TRIGGER` (default `^\s*tcl\s`),
+`SMEGGDROP_CHANNELS` (comma-separated channel IDs, empty = all),
+`SMEGGDROP_STATE`, `SMEGGDROP_TIME_LIMIT`, `SMEGGDROP_WORDS`.
+Retried Slack deliveries are dropped rather than re-evaluated, and request
+signatures are verified by bolt.
+
 `audit` exists so the port can be verified against real accumulated state:
 it loads everything into a throwaway sandbox (nothing persisted, network
 stubbed out), flags procs that fail to load or reference commands that no

--- a/README.md
+++ b/README.md
@@ -85,8 +85,25 @@ lost rather than executed late.
 `audit` exists so the port can be verified against real accumulated state:
 it loads everything into a throwaway sandbox (nothing persisted, network
 stubbed out), flags procs that fail to load or reference commands that no
-longer exist, and actually calls every proc that's callable without
-arguments. Fix, re-run, repeat.
+longer exist, and calls them. `--call-with-args` passes a dummy value per
+required argument so the whole library gets exercised rather than just the
+zero-argument part, and sorts "wanted a number, got `test`" into its own
+bucket instead of counting it as breakage. Fix, re-run, repeat.
+
+Against the hardchats state (6,604 procs accumulated 2007-2017):
+
+| | procs |
+|---|---|
+| ran clean | 5,148 |
+| reached the network (stubbed in audit) | 690 |
+| failed | 516 |
+| wanted different arguments | 249 |
+| failed to load | 0 |
+
+So ~88% demonstrably work. Nearly all remaining failures are data rot
+rather than port breakage: helpers their authors deleted years ago,
+services that no longer resolve (`i.buttes.org`, `magick.buttes.org`), and
+a few deliberate infinite loops.
 
 ## Security model
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ for cold-start overlap, not a licence to run more than one writer.
 
 Config env vars: `SMEGGDROP_TRIGGER` (default `^\s*tcl\s`),
 `SMEGGDROP_CHANNELS` (comma-separated channel IDs, empty = all),
+`SMEGGDROP_BLOCKED_USERS` (comma-separated slack user IDs — not
+names, which anyone can change — silently ignored, no reply),
 `SMEGGDROP_STATE`, `SMEGGDROP_TIME_LIMIT`, `SMEGGDROP_WORDS`,
 `SMEGGDROP_MEMORY_MB` (default 2048, 0 disables).
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ EOF
 ./run-slack-dev.sh state-local          # or any state dir
 ```
 
+Edited state some other way while the bot's up (a one-off `smeggdrop repl`
+fix)? `./reload-bot.sh state-local` reloads it from disk without dropping
+the Slack connection or restarting the process — the reload is queued on
+the same worker thread evals run on, so it can't interrupt one in flight,
+and Socket Mode never reconnects. It's a signal (`SIGHUP`), not a lock:
+the file store still has no cross-process write coordination, so this
+doesn't protect against a repl edit and a live eval writing at the exact
+same instant — it just avoids the multi-second outage a full restart costs.
+
 Slack-specific behaviour worth knowing: mentions are resolved to plain
 nicks on the way in, so procs written for irc see `deathto winkie` rather
 than `deathto <@U03S5JZ7U>`; mIRC colour codes are stripped from replies

--- a/README.md
+++ b/README.md
@@ -69,8 +69,27 @@ Production runs the Events API on Lambda from a container image
 - set **reserved concurrency to 1** — evals are serialized by design
 - grant the function role `lambda:InvokeFunction` on itself (bolt's lazy
   listeners ack within Slack's 3s window, then re-invoke to run the eval)
-- state is ephemeral per warm container until the S3 store lands; mount
-  EFS at `SMEGGDROP_STATE` if you need durability before then
+- set `SMEGGDROP_STATE=s3://bucket/prefix` for durable state, and give the
+  role `s3:GetObject`/`s3:PutObject` on it
+
+## State stores
+
+`--state` (and `SMEGGDROP_STATE`) takes a directory or an `s3://` uri, and
+`migrate` copies between them:
+
+```sh
+uv run smeggdrop --state ./state-local migrate s3://my-bucket/smeggdrop
+```
+
+The directory layout is the perl bot's (one sha1-named file per proc plus
+an `_index`). S3 packs each category into a single JSON object instead:
+6,600 objects would mean 6,600 GETs on every cold start, while the whole
+state is ~6 MB — one GET to load, one PUT per eval that changes something.
+Turn on bucket versioning and every eval becomes a restorable version.
+
+Writes are conditional on the ETag that was loaded, so if a second process
+does write, its changes are merged rather than clobbered. That's a backstop
+for cold-start overlap, not a licence to run more than one writer.
 
 Config env vars: `SMEGGDROP_TRIGGER` (default `^\s*tcl\s`),
 `SMEGGDROP_CHANNELS` (comma-separated channel IDs, empty = all),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = []
 
 [project.optional-dependencies]
 slack = ["slack-bolt>=1.20"]
+lambda = ["slack-bolt>=1.20", "boto3>=1.34"]
 
 [project.scripts]
 smeggdrop = "smeggdrop.cli:main"

--- a/reload-bot.sh
+++ b/reload-bot.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Tell a running bot (started by run-slack-dev.sh) to reload state from
+# disk without dropping its Slack connection or restarting the process.
+#
+#   ./reload-bot.sh [state-dir]      # defaults to ./state-local
+#
+# Use this after editing state some other way (a one-off `smeggdrop repl`
+# fix) while the bot is up: the reload is queued on the same worker thread
+# evals run on, so it can't interrupt one in flight, and the socket-mode
+# connection to Slack is never touched.
+#
+# Caveat: reload only re-syncs the bot's in-memory copy with whatever is on
+# disk. The file state store has no cross-process locking, so if a repl
+# edit and a live Slack eval write at the exact same instant, the second
+# write still wins — reload doesn't add coordination that isn't already
+# there. Fine for a quick one-off fix; not a substitute for the S3 store's
+# conditional writes if that ever matters here.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+STATE="${1:-state-local}"
+PIDFILE="$STATE/.smeggdrop.pid"
+
+if [[ ! -f "$PIDFILE" ]]; then
+  echo "error: no pidfile at $PIDFILE — is the bot running against $STATE?" >&2
+  exit 1
+fi
+
+pid="$(cat "$PIDFILE")"
+if ! kill -0 "$pid" 2>/dev/null; then
+  echo "error: pidfile $PIDFILE points at pid $pid, which isn't running (stale)" >&2
+  exit 1
+fi
+
+kill -HUP "$pid"
+echo "sent reload signal to pid $pid"

--- a/run-slack-dev.sh
+++ b/run-slack-dev.sh
@@ -1,13 +1,31 @@
 #!/usr/bin/env bash
-# Local socket-mode run: reads credentials from .env, state dir as $1.
+# Run the slack bot locally over Socket Mode: no public endpoint, state on
+# disk, safe to Ctrl-C.
 #
-#   ./run-slack-dev.sh ~/dev/smeggdrop-state/hardchats
+#   ./run-slack-dev.sh [state-dir]      # defaults to ./state-local
 #
-# .env needs SLACK_BOT_TOKEN and SLACK_APP_TOKEN (see README).
+# .env (gitignored) needs SLACK_BOT_TOKEN and SLACK_APP_TOKEN — see the
+# README's Slack section for how to mint them.
+#
+# "Safely" here means:
+#   - refuses to start a second instance against the same state dir. The
+#     versioned-eval persistence assumes one writer; two bots racing on the
+#     same files is exactly the kind of self-inflicted corruption that
+#     happened during dev when a repl and a running bot touched the same
+#     state at once.
+#   - the process memory cap (smeggdrop.hardening, default 2048MB) is
+#     always on for the slack subcommand — a single hostile eval can't take
+#     the host down with it.
+#   - state is a plain directory, so it's just files: `git status` in it
+#     before trusting a session, and you can always restore from a backup
+#     or the state repo's own history if a bad eval writes something
+#     unwanted.
 set -euo pipefail
 cd "$(dirname "$0")"
 
 STATE="${1:-state-local}"
+mkdir -p "$STATE"
+LOCK="$STATE/.smeggdrop.lock"
 
 if [[ -f .env ]]; then
   set -a
@@ -18,5 +36,16 @@ fi
 
 : "${SLACK_BOT_TOKEN:?set SLACK_BOT_TOKEN in .env}"
 : "${SLACK_APP_TOKEN:?set SLACK_APP_TOKEN in .env}"
+
+exec 9>"$LOCK"
+if ! flock -n 9; then
+  echo "error: another smeggdrop instance already holds the lock on $STATE" >&2
+  echo "       (check: pgrep -af 'smeggdrop.*--state $STATE')" >&2
+  exit 1
+fi
+
+commit="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+echo "smeggdrop @ $commit ($branch) — state: $STATE — memory cap: ${SMEGGDROP_MEMORY_MB:-2048}MB"
 
 exec uv run --extra slack smeggdrop --state "$STATE" slack

--- a/run-slack-dev.sh
+++ b/run-slack-dev.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Local socket-mode run: reads credentials from .env, state dir as $1.
+#
+#   ./run-slack-dev.sh ~/dev/smeggdrop-state/hardchats
+#
+# .env needs SLACK_BOT_TOKEN and SLACK_APP_TOKEN (see README).
+set -euo pipefail
+cd "$(dirname "$0")"
+
+STATE="${1:-state-local}"
+
+if [[ -f .env ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  . ./.env
+  set +a
+fi
+
+: "${SLACK_BOT_TOKEN:?set SLACK_BOT_TOKEN in .env}"
+: "${SLACK_APP_TOKEN:?set SLACK_APP_TOKEN in .env}"
+
+exec uv run --extra slack smeggdrop --state "$STATE" slack

--- a/slack-app-manifest.yml
+++ b/slack-app-manifest.yml
@@ -1,0 +1,31 @@
+# Create the slack app from this at https://api.slack.com/apps
+# -> "Create New App" -> "From an app manifest"
+#
+# Socket Mode is enabled for local dev (`smeggdrop slack`); for the Lambda
+# deploy, add the function URL as the request URL under Event Subscriptions
+# and Socket Mode can stay on or off (the Events API delivery wins when a
+# request URL is set).
+
+display_information:
+  name: smeggdrop
+  description: Evaluates Tcl in chat rooms
+  background_color: "#2c2d30"
+features:
+  bot_user:
+    display_name: smeggdrop
+    always_online: true
+oauth_config:
+  scopes:
+    bot:
+      - chat:write        # post replies
+      - users:read        # user id -> nick
+      - channels:history  # message events, public channels
+      - groups:history    # message events, private channels
+settings:
+  event_subscriptions:
+    bot_events:
+      - message.channels
+      - message.groups
+  socket_mode_enabled: true
+  org_deploy_enabled: false
+  token_rotation_enabled: false

--- a/smeggdrop/audit.py
+++ b/smeggdrop/audit.py
@@ -51,6 +51,8 @@ class ProcAudit:
     run_ok: bool | None = None
     run_error: str | None = None
     needs_network: bool = False  # only "failed" because audit stubs the network
+    arity: int | None = None  # required args, when it takes any
+    arg_mismatch: bool = False  # failed on the audit's dummy args, not broken
 
     @property
     def healthy(self) -> bool:
@@ -70,8 +72,10 @@ class AuditReport:
             "broken_refs": sum(1 for p in self.procs if p.broken_refs),
             "unknown_refs": sum(1 for p in self.procs if p.unknown_refs),
             "ran": sum(1 for p in self.procs if p.ran),
+            "run_ok": sum(1 for p in self.procs if p.run_ok is True),
             "run_failures": sum(1 for p in self.procs if p.run_ok is False),
             "needs_network": sum(1 for p in self.procs if p.needs_network),
+            "arg_mismatch": sum(1 for p in self.procs if p.arg_mismatch),
             "var_load_failures": len(self.var_load_errors),
         }
 
@@ -89,6 +93,8 @@ def audit_state(
     tcl_dir=None,
     run: bool = True,
     time_limit: int = 2,
+    call_with_args: bool = False,
+    arg_value: str = "test",
 ) -> AuditReport:
     said: list[str] = []
     interp = SafeTclInterp(
@@ -156,21 +162,36 @@ def audit_state(
             for name, report in reports.items():
                 if not report.loaded or report.shadowed:
                     continue
-                if not _callable_without_args(interp, name):
+                required = _required_args(interp, name)
+                if required is None:
                     continue
+                report.arity = len(required)
+                if required and not call_with_args:
+                    continue  # zero-arg procs only
+
+                # procs that take arguments get a generic token per slot;
+                # it exercises far more of the library than zero-arg calls
+                # alone, at the cost of some "wrong kind of argument" noise
+                # that _looks_like_arg_mismatch sorts back out
+                call = (name, *[arg_value] * len(required))
                 report.ran = True
                 try:
-                    interp.eval_limited((name,), time_limit)
+                    interp.eval_limited(call, time_limit)
                     report.run_ok = True
                 except TclError as e:
-                    if NETWORK_STUB_MARKER in str(e):
+                    error = str(e)
+                    if NETWORK_STUB_MARKER in error:
                         # it made it all the way to the fetcher; that's a
                         # working proc, the audit just won't do network
                         report.needs_network = True
                         report.run_ok = None
+                    elif required and _looks_like_arg_mismatch(error):
+                        report.arg_mismatch = True
+                        report.run_ok = None
+                        report.run_error = error
                     else:
                         report.run_ok = False
-                        report.run_error = str(e)
+                        report.run_error = error
 
         return AuditReport(list(reports.values()), var_errors)
     finally:
@@ -184,14 +205,52 @@ def _network_stub(*args):
     raise TclError(NETWORK_STUB_MARKER)
 
 
-def _callable_without_args(interp: SafeTclInterp, name: str) -> bool:
+def _required_args(interp: SafeTclInterp, name: str) -> list[str] | None:
+    """Args with no default, i.e. what a caller must supply. None if the
+    proc can't be introspected."""
     try:
         args = interp.splitlist(interp.eval(("info", "args", name)))
     except TclError:
-        return False
+        return None
+    required = []
     for arg in args:
         if arg == "args":
             continue  # varargs: zero is fine
         if interp.eval(("info", "default", name, arg, "::_audit_default")) != "1":
-            return False
-    return True
+            required.append(arg)
+    return required
+
+
+def _callable_without_args(interp: SafeTclInterp, name: str) -> bool:
+    required = _required_args(interp, name)
+    return required is not None and not required
+
+
+# Errors that mean "the audit's dummy argument was wrong for this proc",
+# not "this proc is broken". A proc wanting a number, a nick that exists, or
+# a specific keyword will reject a generic token, and that is not a defect.
+ARG_MISMATCH_PATTERNS = (
+    "expected integer",
+    "expected floating-point",
+    "expected boolean",
+    "non-numeric string",
+    "can't use empty string as operand",
+    "expected version number",
+    "not in valid range",
+    "no such element in array",
+    "no such variable",
+    "must be ",
+    "bad option",
+    "bad index",
+    "bad command",
+    "invalid bareword",
+    "divide by zero",
+    "list element in braces",
+    "unmatched open brace",
+    "wrong # args",
+)
+
+
+def _looks_like_arg_mismatch(error: str) -> bool:
+    lowered = error.lower()
+    return any(p in lowered for p in ARG_MISMATCH_PATTERNS)

--- a/smeggdrop/audit.py
+++ b/smeggdrop/audit.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import hashlib
 import re
+import urllib.parse
 from dataclasses import asdict, dataclass, field
 
 from smeggdrop.interp import SafeTclInterp, TclError
@@ -43,11 +44,13 @@ class ProcAudit:
     name: str
     loaded: bool = True
     load_error: str | None = None
+    shadowed: bool = False  # a bootstrap alias (cache, meta, ...) hides it
     broken_refs: list[str] = field(default_factory=list)
     unknown_refs: list[str] = field(default_factory=list)
     ran: bool = False
     run_ok: bool | None = None
     run_error: str | None = None
+    needs_network: bool = False  # only "failed" because audit stubs the network
 
     @property
     def healthy(self) -> bool:
@@ -63,10 +66,12 @@ class AuditReport:
         return {
             "total": len(self.procs),
             "load_failures": sum(1 for p in self.procs if not p.loaded),
+            "shadowed": sum(1 for p in self.procs if p.shadowed),
             "broken_refs": sum(1 for p in self.procs if p.broken_refs),
             "unknown_refs": sum(1 for p in self.procs if p.unknown_refs),
             "ran": sum(1 for p in self.procs if p.ran),
             "run_failures": sum(1 for p in self.procs if p.run_ok is False),
+            "needs_network": sum(1 for p in self.procs if p.needs_network),
             "var_load_failures": len(self.var_load_errors),
         }
 
@@ -92,7 +97,9 @@ def audit_state(
             "core::print": lambda *a: "",
             "core::sha1": lambda t="": hashlib.sha1(str(t).encode()).hexdigest(),
             "core::bot_say": lambda *a: said.append(" ".join(str(x) for x in a)) or "",
-            "core::curl": _curl_stub,
+            "core::curl": _network_stub,
+            "core::http": _network_stub,
+            "core::urlencode": lambda t="": urllib.parse.quote_plus(str(t)),
             "core::words": lambda: (),
         },
     )
@@ -119,7 +126,14 @@ def audit_state(
         for name, report in reports.items():
             if not report.loaded:
                 continue
-            body = interp.eval(("info", "body", name))
+            try:
+                body = interp.eval(("info", "body", name))
+            except TclError:
+                # a bootstrap alias with the same global name replaced this
+                # saved proc after load, exactly like the perl loader did;
+                # the saved body is inert so there's nothing to scan or run
+                report.shadowed = True
+                continue
             for ref in sorted(set(CMD_POSITION.findall(body))):
                 if ref == name:
                     continue
@@ -137,23 +151,34 @@ def audit_state(
             )
             interp.set_command_vars(nick="audit", mask="audit@audit", channel="#audit", line="")
             for name, report in reports.items():
-                if not report.loaded or not _callable_without_args(interp, name):
+                if not report.loaded or report.shadowed:
+                    continue
+                if not _callable_without_args(interp, name):
                     continue
                 report.ran = True
                 try:
                     interp.eval_limited((name,), time_limit)
                     report.run_ok = True
                 except TclError as e:
-                    report.run_ok = False
-                    report.run_error = str(e)
+                    if NETWORK_STUB_MARKER in str(e):
+                        # it made it all the way to the fetcher; that's a
+                        # working proc, the audit just won't do network
+                        report.needs_network = True
+                        report.run_ok = None
+                    else:
+                        report.run_ok = False
+                        report.run_error = str(e)
 
         return AuditReport(list(reports.values()), var_errors)
     finally:
         interp.close()
 
 
-def _curl_stub(*args):
-    raise TclError("core::curl is disabled during audit")
+NETWORK_STUB_MARKER = "network is disabled during audit"
+
+
+def _network_stub(*args):
+    raise TclError(NETWORK_STUB_MARKER)
 
 
 def _callable_without_args(interp: SafeTclInterp, name: str) -> bool:

--- a/smeggdrop/audit.py
+++ b/smeggdrop/audit.py
@@ -148,6 +148,9 @@ def audit_state(
             interp.set_context(
                 nick="audit", mask="audit@audit", channel="#audit",
                 command="", nicks=("audit",),
+                # a plausible line of chatter: procs that read [log] should
+                # exercise their real path, not fail on an unset variable
+                log=((0, "audit", "audit@audit", "hello"),),
             )
             interp.set_command_vars(nick="audit", mask="audit@audit", channel="#audit", line="")
             for name, report in reports.items():

--- a/smeggdrop/audit.py
+++ b/smeggdrop/audit.py
@@ -53,6 +53,7 @@ class ProcAudit:
     needs_network: bool = False  # only "failed" because audit stubs the network
     arity: int | None = None  # required args, when it takes any
     arg_mismatch: bool = False  # failed on the audit's dummy args, not broken
+    timed_out: bool = False  # too slow for the audit's limit, not necessarily broken
 
     @property
     def healthy(self) -> bool:
@@ -76,6 +77,7 @@ class AuditReport:
             "run_failures": sum(1 for p in self.procs if p.run_ok is False),
             "needs_network": sum(1 for p in self.procs if p.needs_network),
             "arg_mismatch": sum(1 for p in self.procs if p.arg_mismatch),
+            "timed_out": sum(1 for p in self.procs if p.timed_out),
             "var_load_failures": len(self.var_load_errors),
         }
 
@@ -185,6 +187,12 @@ def audit_state(
                         # working proc, the audit just won't do network
                         report.needs_network = True
                         report.run_ok = None
+                    elif "time limit exceeded" in error:
+                        # slow, or an infinite loop; the audit can't tell
+                        # which, and its limit is tighter than the bot's
+                        report.timed_out = True
+                        report.run_ok = None
+                        report.run_error = error
                     elif required and _looks_like_arg_mismatch(error):
                         report.arg_mismatch = True
                         report.run_ok = None

--- a/smeggdrop/cli.py
+++ b/smeggdrop/cli.py
@@ -121,6 +121,9 @@ def cmd_repl(args) -> int:
 
 
 def cmd_slack(args) -> int:
+    import os
+    import signal
+
     from smeggdrop.hardening import apply_memory_limit
     from smeggdrop.platforms.slack import SlackConfig, run_socket_mode
 
@@ -132,9 +135,34 @@ def cmd_slack(args) -> int:
         limits=Limits(eval_time_seconds=cfg.time_limit),
         words_file=cfg.words_file,
     )
+
+    def on_hup(signum, frame):
+        # runs on the main thread; reload() just enqueues onto the same
+        # worker thread evals use, so this never interrupts one in flight
+        log = logging.getLogger("smeggdrop.cli")
+        log.info("SIGHUP received, reloading state from disk")
+        try:
+            errors = engine.reload()
+            log.info("reload complete (%d load errors)", len(errors))
+        except Exception:
+            log.exception("reload failed")
+
+    signal.signal(signal.SIGHUP, on_hup)
+
+    # written for reload-bot.sh to find us: `uv run` forks rather than
+    # execing, so the launching shell's $$ isn't this process's pid — only
+    # we know our own pid reliably, for a file store only (an s3 uri has
+    # no local directory to drop a pidfile in, and Lambda doesn't need one)
+    pidfile = None
+    if not args.state.startswith("s3://"):
+        pidfile = Path(args.state) / ".smeggdrop.pid"
+        pidfile.write_text(str(os.getpid()))
+
     try:
         run_socket_mode(engine, cfg)
     finally:
+        if pidfile is not None:
+            pidfile.unlink(missing_ok=True)
         engine.close()
     return 0
 

--- a/smeggdrop/cli.py
+++ b/smeggdrop/cli.py
@@ -29,7 +29,12 @@ def main(argv: list[str] | None = None) -> int:
     audit = sub.add_parser("audit", help="check every saved proc: loads? runs? dead refs?")
     audit.add_argument("--json", action="store_true", help="full report as json")
     audit.add_argument("--no-run", action="store_true", help="skip calling zero-arg procs")
-    audit.add_argument("--time-limit", type=int, default=2, help="seconds per proc call")
+    audit.add_argument(
+        "--time-limit",
+        type=int,
+        default=Limits.eval_time_seconds,
+        help="seconds per proc call (default: same as the bot allows)",
+    )
     audit.add_argument(
         "--call-with-args",
         action="store_true",
@@ -156,6 +161,7 @@ def cmd_audit(args) -> int:
             f"{summary['needs_network']} need network, "
             f"{summary['run_failures']} failed, "
             f"{summary['arg_mismatch']} wanted different arguments, "
+            f"{summary['timed_out']} timed out, "
             f"{summary['load_failures']} failed to load, "
             f"{summary['broken_refs']} reference dead commands, "
             f"{summary['var_load_failures']} var load failures"

--- a/smeggdrop/cli.py
+++ b/smeggdrop/cli.py
@@ -38,10 +38,15 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     args = parser.parse_args(argv)
-    logging.basicConfig(
-        level=logging.DEBUG if args.verbose else logging.WARNING,
-        format="%(levelname)s %(name)s: %(message)s",
-    )
+    if args.verbose:
+        level = logging.DEBUG
+    elif args.command == "slack":
+        # running as a bot: the operator wants to see what is being
+        # evaluated and by whom, not just failures
+        level = logging.INFO
+    else:
+        level = logging.WARNING
+    logging.basicConfig(level=level, format="%(levelname)s %(name)s: %(message)s")
 
     if args.command == "repl":
         return cmd_repl(args)
@@ -94,8 +99,10 @@ def cmd_repl(args) -> int:
 
 
 def cmd_slack(args) -> int:
+    from smeggdrop.hardening import apply_memory_limit
     from smeggdrop.platforms.slack import SlackConfig, run_socket_mode
 
+    apply_memory_limit()
     cfg = SlackConfig.from_env()
     engine = Engine(
         FileStateStore(args.state),

--- a/smeggdrop/cli.py
+++ b/smeggdrop/cli.py
@@ -30,6 +30,12 @@ def main(argv: list[str] | None = None) -> int:
     audit.add_argument("--json", action="store_true", help="full report as json")
     audit.add_argument("--no-run", action="store_true", help="skip calling zero-arg procs")
     audit.add_argument("--time-limit", type=int, default=2, help="seconds per proc call")
+    audit.add_argument(
+        "--call-with-args",
+        action="store_true",
+        help="also call procs that take arguments, passing a dummy value per slot",
+    )
+    audit.add_argument("--arg-value", default="test", help="dummy argument (default: test)")
 
     sub.add_parser(
         "slack",
@@ -120,7 +126,12 @@ def cmd_slack(args) -> int:
 def cmd_audit(args) -> int:
     store = FileStateStore(args.state)
     report = audit_state(
-        store, tcl_dir=args.tcl_dir, run=not args.no_run, time_limit=args.time_limit
+        store,
+        tcl_dir=args.tcl_dir,
+        run=not args.no_run,
+        time_limit=args.time_limit,
+        call_with_args=args.call_with_args,
+        arg_value=args.arg_value,
     )
 
     if args.json:
@@ -141,10 +152,12 @@ def cmd_audit(args) -> int:
         summary = report.summary()
         print(
             f"\n{summary['total']} procs: "
-            f"{summary['load_failures']} load failures, "
-            f"{summary['broken_refs']} with broken refs, "
-            f"{summary['run_failures']}/{summary['ran']} run failures, "
-            f"{summary['unknown_refs']} suspect, "
+            f"{summary['run_ok']} ran clean, "
+            f"{summary['needs_network']} need network, "
+            f"{summary['run_failures']} failed, "
+            f"{summary['arg_mismatch']} wanted different arguments, "
+            f"{summary['load_failures']} failed to load, "
+            f"{summary['broken_refs']} reference dead commands, "
             f"{summary['var_load_failures']} var load failures"
         )
 

--- a/smeggdrop/cli.py
+++ b/smeggdrop/cli.py
@@ -10,12 +10,16 @@ from pathlib import Path
 
 from smeggdrop.audit import audit_state
 from smeggdrop.engine import Engine, EvalRequest, Limits
-from smeggdrop.state import FileStateStore
+from smeggdrop.state import CATEGORIES, open_store
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="smeggdrop")
-    parser.add_argument("--state", default="state", help="state directory (default: ./state)")
+    parser.add_argument(
+        "--state",
+        default="state",
+        help="state directory, or s3://bucket/prefix (default: ./state)",
+    )
     parser.add_argument("--tcl-dir", default=None, help="override bundled tcl bootstrap dir")
     parser.add_argument("-v", "--verbose", action="store_true")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -42,6 +46,11 @@ def main(argv: list[str] | None = None) -> int:
     )
     audit.add_argument("--arg-value", default="test", help="dummy argument (default: test)")
 
+    migrate = sub.add_parser(
+        "migrate", help="copy state into another store (e.g. a file dir into s3)"
+    )
+    migrate.add_argument("destination", help="target directory or s3://bucket/prefix")
+
     sub.add_parser(
         "slack",
         help="run the slack bot over socket mode "
@@ -63,6 +72,8 @@ def main(argv: list[str] | None = None) -> int:
         return cmd_repl(args)
     if args.command == "slack":
         return cmd_slack(args)
+    if args.command == "migrate":
+        return cmd_migrate(args)
     return cmd_audit(args)
 
 
@@ -73,7 +84,7 @@ def cmd_repl(args) -> int:
         pass
 
     engine = Engine(
-        FileStateStore(args.state),
+        open_store(args.state),
         tcl_dir=args.tcl_dir,
         limits=Limits(eval_time_seconds=args.time_limit),
         words_file=args.words,
@@ -116,7 +127,7 @@ def cmd_slack(args) -> int:
     apply_memory_limit()
     cfg = SlackConfig.from_env()
     engine = Engine(
-        FileStateStore(args.state),
+        open_store(args.state),
         tcl_dir=args.tcl_dir,
         limits=Limits(eval_time_seconds=cfg.time_limit),
         words_file=cfg.words_file,
@@ -128,8 +139,19 @@ def cmd_slack(args) -> int:
     return 0
 
 
+def cmd_migrate(args) -> int:
+    source = open_store(args.state)
+    destination = open_store(args.destination)
+    for category in CATEGORIES:
+        entries = source.load(category)
+        destination.load(category)  # so an existing destination is merged, not replaced
+        destination.save_many(category, entries)
+        print(f"{category}: copied {len(entries)}")
+    return 0
+
+
 def cmd_audit(args) -> int:
-    store = FileStateStore(args.state)
+    store = open_store(args.state)
     report = audit_state(
         store,
         tcl_dir=args.tcl_dir,

--- a/smeggdrop/cli.py
+++ b/smeggdrop/cli.py
@@ -31,6 +31,12 @@ def main(argv: list[str] | None = None) -> int:
     audit.add_argument("--no-run", action="store_true", help="skip calling zero-arg procs")
     audit.add_argument("--time-limit", type=int, default=2, help="seconds per proc call")
 
+    sub.add_parser(
+        "slack",
+        help="run the slack bot over socket mode "
+        "(needs SLACK_BOT_TOKEN, SLACK_APP_TOKEN; config via SMEGGDROP_* env)",
+    )
+
     args = parser.parse_args(argv)
     logging.basicConfig(
         level=logging.DEBUG if args.verbose else logging.WARNING,
@@ -39,6 +45,8 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "repl":
         return cmd_repl(args)
+    if args.command == "slack":
+        return cmd_slack(args)
     return cmd_audit(args)
 
 
@@ -80,6 +88,23 @@ def cmd_repl(args) -> int:
                     print(result.output)
             else:
                 print(f"error: {result.output}")
+    finally:
+        engine.close()
+    return 0
+
+
+def cmd_slack(args) -> int:
+    from smeggdrop.platforms.slack import SlackConfig, run_socket_mode
+
+    cfg = SlackConfig.from_env()
+    engine = Engine(
+        FileStateStore(args.state),
+        tcl_dir=args.tcl_dir,
+        limits=Limits(eval_time_seconds=cfg.time_limit),
+        words_file=cfg.words_file,
+    )
+    try:
+        run_socket_mode(engine, cfg)
     finally:
         engine.close()
     return 0

--- a/smeggdrop/engine.py
+++ b/smeggdrop/engine.py
@@ -107,6 +107,7 @@ class Engine:
         self._curl_calls = 0
         self.load_errors: dict[str, str] = {}
         self._closed = False
+        self._tcl_dir = tcl_dir
         self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="smeggdrop-tcl")
         self._executor.submit(self._init_interp, tcl_dir).result()
 
@@ -130,7 +131,33 @@ class Engine:
         future = self._executor.submit(self._eval, req, say)
         return future.result(timeout if timeout is not None else self.limits.eval_time_seconds + 30)
 
+    def reload(self, timeout: float = 60) -> dict[str, str]:
+        """Rebuild the interpreter from scratch, re-reading state from disk.
+
+        For picking up procs/vars written some other way (a one-off repl
+        fix, another operator) without dropping the platform connection —
+        unlike a full process restart, which for a Slack Socket Mode bot
+        means a lost connection and a several-second gap where messages
+        can go unanswered. Runs on the same worker thread as eval(), so it
+        can never interleave with an in-flight eval; it just queues behind
+        whatever's currently running. Nothing in memory is lost by this:
+        state is written to disk synchronously after every eval, so disk
+        is always the authoritative copy.
+
+        Returns the fresh load_errors (also left on self.load_errors).
+        """
+        future = self._executor.submit(self._reload)
+        return future.result(timeout)
+
     # -- worker-thread internals ---------------------------------------
+
+    def _reload(self) -> dict[str, str]:
+        old_interp = self.interp
+        self.load_errors = {}
+        self._words = None
+        self._init_interp(self._tcl_dir)
+        old_interp.close()
+        return self.load_errors
 
     def _init_interp(self, tcl_dir) -> None:
         self.interp = SafeTclInterp(

--- a/smeggdrop/engine.py
+++ b/smeggdrop/engine.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import urllib.parse
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -54,6 +55,9 @@ class EvalRequest:
     channel: str | None = None
     mask: str | None = None
     nicks: tuple[str, ...] = ()
+    # recent channel chatter as (unix_ts, nick, mask, text) rows; reachable
+    # in the sandbox via [log]
+    loglines: tuple[tuple, ...] = ()
 
 
 @dataclass
@@ -63,11 +67,17 @@ class EvalResult:
     warnings: list[str] = field(default_factory=list)
 
 
+# tcl sets these automatically whenever an error is caught; persisting them
+# is pure churn (the legacy bot did, which is how junk errorInfo entries
+# ended up in old state dirs)
+AUTOMATIC_VARS = frozenset({"errorInfo", "errorCode"})
+
+
 def diff_category(pre: dict[str, str], post: dict[str, str]) -> dict[str, str | None]:
     """Changed entries between snapshots; None means deleted."""
     changed: dict[str, str | None] = {}
     for name in pre.keys() | post.keys():
-        if name.startswith("context::"):
+        if name.startswith("context::") or name in AUTOMATIC_VARS:
             continue
         a, b = pre.get(name), post.get(name)
         if a != b:
@@ -129,6 +139,8 @@ class Engine:
                 "core::print": self._b_print,
                 "core::sha1": self._b_sha1,
                 "core::curl": self._b_curl,
+                "core::http": self._b_http,
+                "core::urlencode": self._b_urlencode,
                 "core::bot_say": self._b_say,
                 "core::words": self._b_words,
             },
@@ -158,6 +170,7 @@ class Engine:
                 channel=req.channel,
                 command=req.code,
                 nicks=req.nicks,
+                log=req.loglines,
             )
             interp.set_command_vars(
                 nick=req.nick, mask=req.mask, channel=req.channel, line=req.code
@@ -221,14 +234,28 @@ class Engine:
         return hashlib.sha1(str(text).encode("utf-8")).hexdigest()
 
     def _b_curl(self, url="") -> tuple[str, str]:
+        status, _headers, body = self._fetch("core::curl", str(url))
+        return (str(status), body)
+
+    def _b_http(self, method="GET", url="", body="") -> tuple[str, tuple, str]:
+        """[code {header value ...} body] — the shape the old http.tcl returned."""
+        status, headers, resp_body = self._fetch("core::http", str(url), str(method), str(body))
+        flat: list[str] = []
+        for k, v in headers.items():
+            flat.extend((k, v))
+        return (str(status), tuple(flat), resp_body)
+
+    def _fetch(self, who: str, url: str, method: str = "GET", body: str | None = None):
         self._curl_calls += 1
         if self._curl_calls > self.limits.curl_max_calls:
-            raise TclError(f"core::curl: limit of {self.limits.curl_max_calls} fetches per eval")
+            raise TclError(f"{who}: limit of {self.limits.curl_max_calls} fetches per eval")
         try:
-            status, body = self.fetcher.fetch(str(url))
+            return self.fetcher.fetch(url, method=method, body=body)
         except FetchError as e:
-            raise TclError(f"core::curl: {e}") from e
-        return (str(status), body)
+            raise TclError(f"{who}: {e}") from e
+
+    def _b_urlencode(self, text="") -> str:
+        return urllib.parse.quote_plus(str(text))
 
     def _b_say(self, *args) -> str:
         self._say_calls += 1

--- a/smeggdrop/hardening.py
+++ b/smeggdrop/hardening.py
@@ -1,0 +1,59 @@
+"""Process-level containment for the bot.
+
+The Tcl sandbox stops chat code from touching the filesystem, the network
+(except through the guarded fetcher) and the process environment. What it
+cannot stop is a single well-formed command asking for absurd resources:
+`string repeat x 9999999999` is one command, so neither the time limit nor
+the command limit sees it coming — Tcl just tries the allocation.
+
+An address-space rlimit turns that from "the host starts swapping and the
+OOM killer picks a victim" into "this process dies and the supervisor
+restarts it". Tcl's allocator aborts on failure, so the bot does not
+survive the hit; that is the intended trade. Restarting is cheap (state is
+on disk), and a hostile eval taking down someone else's process on the
+same box is not.
+
+Applied at startup by the CLI; on Lambda the platform already caps memory
+so this is a no-op unless SMEGGDROP_MEMORY_MB is set.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+log = logging.getLogger(__name__)
+
+DEFAULT_MEMORY_MB = 2048
+
+
+def apply_memory_limit(megabytes: int | None = None) -> int | None:
+    """Cap the process address space. Returns the applied cap, or None.
+
+    Reads SMEGGDROP_MEMORY_MB when no value is passed; set it to 0 to
+    disable. Never raises — a missing rlimit is a weaker deployment, not a
+    reason to refuse to start.
+    """
+    if megabytes is None:
+        raw = os.environ.get("SMEGGDROP_MEMORY_MB")
+        megabytes = DEFAULT_MEMORY_MB if raw is None else int(raw)
+    if not megabytes:
+        return None
+
+    try:
+        import resource
+    except ImportError:  # not posix
+        log.warning("no resource module; memory limit not applied")
+        return None
+
+    limit = megabytes * 1024 * 1024
+    soft, hard = resource.getrlimit(resource.RLIMIT_AS)
+    if hard != resource.RLIM_INFINITY and limit > hard:
+        limit = hard
+    try:
+        resource.setrlimit(resource.RLIMIT_AS, (limit, hard))
+    except (ValueError, OSError) as e:
+        log.warning("could not set memory limit: %s", e)
+        return None
+    log.info("address space capped at %d MB", limit // (1024 * 1024))
+    return limit // (1024 * 1024)

--- a/smeggdrop/interp.py
+++ b/smeggdrop/interp.py
@@ -57,6 +57,18 @@ class SafeTclInterp:
         # tzdata off disk), so run clock in the master on the slave's behalf
         self.tk.call("interp", "alias", self.slave, "clock", "", "clock")
 
+        # `encoding` is hidden in safe interps because `encoding system`
+        # mutates process state; the read-only subcommands are harmless and
+        # plenty of saved procs use them
+        self.tk.call(
+            "proc", "::_smeggdrop_encoding", "args",
+            'set sub [lindex $args 0]\n'
+            'if {$sub ni {convertfrom convertto names}} '
+            '{error "encoding $sub is not allowed in the sandbox"}\n'
+            "uplevel #0 [linsert $args 0 encoding]",
+        )
+        self.tk.call("interp", "alias", self.slave, "encoding", "", "::_smeggdrop_encoding")
+
         for name, fn in (builtins or {}).items():
             self.register_builtin(name, fn)
 

--- a/smeggdrop/interp.py
+++ b/smeggdrop/interp.py
@@ -32,6 +32,7 @@ BOOTSTRAP_FILES = (
     "commands.tcl",
     "meta.tcl",
     "cache.tcl",
+    "httpx.tcl",
     "bootstrap.tcl",
 )
 SLAVE = "smeggdrop"

--- a/smeggdrop/interp.py
+++ b/smeggdrop/interp.py
@@ -183,12 +183,31 @@ class SafeTclInterp:
         out = {}
         for name in self.splitlist(self.eval("info procs")):
             try:
-                args = self.eval(("info", "args", name))
+                args = self.arg_spec(name)
                 body = self.eval(("info", "body", name))
             except TclError:
                 continue
             out[name] = "{%s} {%s}" % (args, body)
         return out
+
+    def arg_spec(self, name: str) -> str:
+        """Rebuild a proc's argument list *with* default values.
+
+        `info args` returns bare names, so serializing from it silently
+        drops defaults and turns `proc p {{x 1}}` into `proc p {x}` — a
+        proc that used to be callable with no arguments stops being one.
+        `info default` recovers them.
+        """
+        spec = []
+        for arg in self.splitlist(self.eval(("info", "args", name))):
+            has_default = self.eval(("info", "default", name, arg, "::_smeggdrop_default"))
+            if has_default == "1":
+                default = self.eval(("set", "::_smeggdrop_default"))
+                spec.append(self.eval(("list", arg, default)))
+            else:
+                spec.append(arg)
+        self.eval("catch {unset ::_smeggdrop_default}")
+        return self.eval(("list", *spec)) if spec else ""
 
     def vars(self) -> dict[str, str]:
         out = {}

--- a/smeggdrop/interp.py
+++ b/smeggdrop/interp.py
@@ -47,6 +47,12 @@ class SafeTclInterp:
         self.slave = SLAVE
         self.tk.call("interp", "create", "-safe", self.slave)
 
+        # Stash the builtin lambda [apply] before anything can shadow it —
+        # commands.tcl installs smeggdrop's own [apply] (a different
+        # convention), and saved procs use both. bootstrap.tcl defines a
+        # dispatcher that needs the real one under this name.
+        self.eval("catch {rename apply tcl_apply}")
+
         tcl_dir = Path(tcl_dir) if tcl_dir else DEFAULT_TCL_DIR
         for name in BOOTSTRAP_FILES:
             path = tcl_dir / name

--- a/smeggdrop/interp.py
+++ b/smeggdrop/interp.py
@@ -99,8 +99,16 @@ class SafeTclInterp:
     def eval_limited(self, script, seconds: int) -> str:
         """Evaluate with a wall-clock limit enforced by the master.
 
-        Slaves cannot modify their own limits, so sandboxed code can't
-        lift this.
+        Slaves cannot modify their own limits, so sandboxed code can't lift
+        this.
+
+        Deliberately not using tcl's `command` limit as well: its counter is
+        cumulative for the life of the interpreter, not per-eval, so any
+        fixed ceiling is permanently tripped by the first runaway loop and
+        every later eval fails with "command count limit exceeded". Tcl
+        checks the time limit at the same granularity anyway, so the clock
+        catches tight loops on its own; single huge allocations are handled
+        by the process memory cap (see hardening.py).
         """
         deadline = int(time.time()) + max(1, int(seconds))
         self.tk.call("interp", "limit", self.slave, "time", "-seconds", deadline)

--- a/smeggdrop/lambda_handler.py
+++ b/smeggdrop/lambda_handler.py
@@ -2,10 +2,12 @@
 
 The engine and bolt app are built once per execution environment and reused
 across invocations, so the interp stays warm. Evals are serialized by the
-engine's worker thread; run this function with reserved concurrency 1 until
-the S3 state store lands — with the file store, state only persists for the
-life of a warm container (mount EFS at SMEGGDROP_STATE if you need
-durability before then).
+engine's worker thread; run this function with reserved concurrency 1.
+
+Point SMEGGDROP_STATE at s3://bucket/prefix for durable state — the file
+store only lasts as long as a warm container. The S3 store merges
+concurrent writers rather than clobbering them, but single-writer is still
+the intended configuration.
 
 Lazy listeners re-invoke this same function (bolt's FaaS pattern), so the
 function role needs lambda:InvokeFunction on itself.
@@ -25,11 +27,11 @@ def _handler():
 
     from smeggdrop.engine import Engine, Limits
     from smeggdrop.platforms.slack import SlackConfig, build_app
-    from smeggdrop.state import FileStateStore
+    from smeggdrop.state import open_store
 
     cfg = SlackConfig.from_env()
     engine = Engine(
-        FileStateStore(cfg.state_dir),
+        open_store(cfg.state_dir),
         limits=Limits(eval_time_seconds=cfg.time_limit),
         words_file=cfg.words_file,
     )

--- a/smeggdrop/lambda_handler.py
+++ b/smeggdrop/lambda_handler.py
@@ -33,7 +33,7 @@ def _handler():
         limits=Limits(eval_time_seconds=cfg.time_limit),
         words_file=cfg.words_file,
     )
-    return SlackRequestHandler(build_app(engine, cfg))
+    return SlackRequestHandler(build_app(engine, cfg, lazy=True))
 
 
 def handler(event, context):

--- a/smeggdrop/lambda_handler.py
+++ b/smeggdrop/lambda_handler.py
@@ -1,0 +1,40 @@
+"""AWS Lambda entrypoint for the slack adapter (Events API).
+
+The engine and bolt app are built once per execution environment and reused
+across invocations, so the interp stays warm. Evals are serialized by the
+engine's worker thread; run this function with reserved concurrency 1 until
+the S3 state store lands — with the file store, state only persists for the
+life of a warm container (mount EFS at SMEGGDROP_STATE if you need
+durability before then).
+
+Lazy listeners re-invoke this same function (bolt's FaaS pattern), so the
+function role needs lambda:InvokeFunction on itself.
+"""
+
+from __future__ import annotations
+
+import logging
+from functools import lru_cache
+
+logging.basicConfig(level=logging.INFO)
+
+
+@lru_cache(maxsize=1)
+def _handler():
+    from slack_bolt.adapter.aws_lambda import SlackRequestHandler
+
+    from smeggdrop.engine import Engine, Limits
+    from smeggdrop.platforms.slack import SlackConfig, build_app
+    from smeggdrop.state import FileStateStore
+
+    cfg = SlackConfig.from_env()
+    engine = Engine(
+        FileStateStore(cfg.state_dir),
+        limits=Limits(eval_time_seconds=cfg.time_limit),
+        words_file=cfg.words_file,
+    )
+    return SlackRequestHandler(build_app(engine, cfg))
+
+
+def handler(event, context):
+    return _handler().handle(event, context)

--- a/smeggdrop/platforms/__init__.py
+++ b/smeggdrop/platforms/__init__.py
@@ -13,8 +13,10 @@ import re
 import time
 from collections import deque
 
-# same default the perl bot shipped: "tcl expr 1+1"
-DEFAULT_TRIGGER = re.compile(r"^\s*tcl\s")
+# same default the perl bot shipped: "tcl expr 1+1", but case-insensitive:
+# phone keyboards autocapitalize the first word, so half the messages from
+# mobile arrive as "Tcl ..." and would otherwise be silently ignored
+DEFAULT_TRIGGER = re.compile(r"^\s*tcl\s", re.IGNORECASE)
 
 
 def extract_code(text: str, trigger: re.Pattern[str] = DEFAULT_TRIGGER) -> str | None:

--- a/smeggdrop/platforms/__init__.py
+++ b/smeggdrop/platforms/__init__.py
@@ -10,6 +10,8 @@ in beside it as a new module, not a refactor.
 from __future__ import annotations
 
 import re
+import time
+from collections import deque
 
 # same default the perl bot shipped: "tcl expr 1+1"
 DEFAULT_TRIGGER = re.compile(r"^\s*tcl\s")
@@ -23,6 +25,28 @@ def extract_code(text: str, trigger: re.Pattern[str] = DEFAULT_TRIGGER) -> str |
     if not match:
         return None
     return trigger.sub("", text, count=1)
+
+
+class ChatLog:
+    """Recent non-trigger chatter per channel, fed to evals as [log].
+
+    Same shape the perl bot kept: (unix_ts, nick, mask, text) rows,
+    accumulated between evals and drained (slurped) by the next one.
+    In-memory only — on Lambda this survives per warm container, which
+    matches how ephemeral the old in-process log was.
+    """
+
+    def __init__(self, max_lines: int = 100):
+        self._max = max_lines
+        self._logs: dict[str, deque] = {}
+
+    def append(self, channel: str, nick: str, mask: str | None, text: str) -> None:
+        log = self._logs.setdefault(channel, deque(maxlen=self._max))
+        log.append((int(time.time()), nick, mask or "", text))
+
+    def slurp(self, channel: str) -> tuple[tuple, ...]:
+        log = self._logs.pop(channel, None)
+        return tuple(log) if log else ()
 
 
 def chunk_output(text: str, max_chunk: int, max_chunks: int) -> list[str]:

--- a/smeggdrop/platforms/slack.py
+++ b/smeggdrop/platforms/slack.py
@@ -20,6 +20,7 @@ import html
 import logging
 import os
 import re
+from collections import OrderedDict
 from dataclasses import dataclass
 
 from smeggdrop.engine import Engine, EvalRequest
@@ -140,6 +141,39 @@ def format_reply(ok: bool, output: str, warnings: list[str]) -> list[str]:
         messages = messages[:MAX_MESSAGES]
         messages[-1] += "\n(truncated)"
     return [f"```{m}```" for m in messages]
+
+
+class EventDeduper:
+    """Remembers which slack event ids have been taken on.
+
+    Retries do not mean "already done" — slack retries when it got no ack,
+    which is exactly what happens while the bot is restarting. Dropping
+    every retry loses those messages silently. Dropping by event id instead
+    is the property actually wanted: run each event at most once, but do
+    run one whose first delivery we never saw.
+    """
+
+    def __init__(self, capacity: int = 2048):
+        self.capacity = capacity
+        self._seen: OrderedDict[str, None] = OrderedDict()
+
+    def claim(self, event_id: str | None) -> bool:
+        """Record an event id. False if it was already claimed."""
+        if not event_id:
+            return True  # nothing to dedupe on; better to run than to drop
+        if event_id in self._seen:
+            self._seen.move_to_end(event_id)
+            return False
+        self._seen[event_id] = None
+        while len(self._seen) > self.capacity:
+            self._seen.popitem(last=False)
+        return True
+
+
+def event_id_of(body) -> str | None:
+    if isinstance(body, dict):
+        return body.get("event_id")
+    return None
 
 
 def retry_attempt(headers) -> int:
@@ -304,15 +338,22 @@ def build_app(engine: Engine, cfg: SlackConfig, *, lazy: bool = False, **app_kwa
     nicks = NickCache()
     channels = ChannelCache()
     chat_log = ChatLog()
+    deduper = EventDeduper()
 
     @app.middleware
-    def drop_retries(request, next):
-        # A retried delivery means our ack was slow, not that the eval
-        # didn't happen; re-running user code is worse than dropping.
-        # The header is present on FIRST delivery too, valued 0 — testing
-        # for presence alone silently drops every single message.
-        if retry_attempt(request.headers) > 0:
-            log.info("dropping retried delivery")
+    def drop_duplicates(request, next):
+        # Run each event at most once. Note the retry header is present on
+        # first delivery too, valued 0, so testing for its presence drops
+        # everything; and a retry whose original we never handled (bot was
+        # restarting) still deserves to run, so key off the event id rather
+        # than the retry counter.
+        event_id = event_id_of(request.body)
+        if not deduper.claim(event_id):
+            log.info(
+                "dropping duplicate delivery of %s (retry %d)",
+                event_id,
+                retry_attempt(request.headers),
+            )
             return
         next()
 

--- a/smeggdrop/platforms/slack.py
+++ b/smeggdrop/platforms/slack.py
@@ -20,7 +20,7 @@ import html
 import logging
 import os
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 from smeggdrop.engine import Engine, EvalRequest
 from smeggdrop.platforms import DEFAULT_TRIGGER, chunk_output, extract_code

--- a/smeggdrop/platforms/slack.py
+++ b/smeggdrop/platforms/slack.py
@@ -23,7 +23,7 @@ import re
 from dataclasses import dataclass
 
 from smeggdrop.engine import Engine, EvalRequest
-from smeggdrop.platforms import DEFAULT_TRIGGER, chunk_output, extract_code
+from smeggdrop.platforms import DEFAULT_TRIGGER, ChatLog, chunk_output, extract_code
 
 log = logging.getLogger(__name__)
 
@@ -118,7 +118,12 @@ class NickCache:
 
 
 def handle_message_event(
-    engine: Engine, client, event: dict, cfg: SlackConfig, nicks: NickCache | None = None
+    engine: Engine,
+    client,
+    event: dict,
+    cfg: SlackConfig,
+    nicks: NickCache | None = None,
+    chat_log: ChatLog | None = None,
 ) -> bool:
     """Process one message event. Returns True if an eval ran."""
     subtype = event.get("subtype")
@@ -136,16 +141,24 @@ def handle_message_event(
         return False
 
     text = msg.get("text") or ""
-    code = extract_code(unfuck_slack_message(text), cfg.trigger)
-    if code is None or not code.strip():
-        return False
-
     user_id = msg.get("user") or ""
     nick = (nicks or NickCache()).resolve(client, user_id) if user_id else msg.get("username", "unknown")
-    log.info("eval from %s in %s: %r", nick, channel, code[:120])
 
+    code = extract_code(unfuck_slack_message(text), cfg.trigger)
+    if code is None or not code.strip():
+        if chat_log is not None and text:
+            chat_log.append(channel, nick, user_id or None, text)
+        return False
+
+    log.info("eval from %s in %s: %r", nick, channel, code[:120])
     result = engine.eval(
-        EvalRequest(code=code, nick=nick, channel=channel, mask=user_id or None),
+        EvalRequest(
+            code=code,
+            nick=nick,
+            channel=channel,
+            mask=user_id or None,
+            loglines=chat_log.slurp(channel) if chat_log is not None else (),
+        ),
         say=lambda t: client.chat_postMessage(channel=channel, text=t),
     )
     for message in format_reply(result.ok, result.output, result.warnings):
@@ -159,6 +172,7 @@ def build_app(engine: Engine, cfg: SlackConfig, **app_kwargs):
 
     app = App(process_before_response=True, **app_kwargs)
     nicks = NickCache()
+    chat_log = ChatLog()
 
     @app.middleware
     def drop_retries(request, next):
@@ -173,7 +187,7 @@ def build_app(engine: Engine, cfg: SlackConfig, **app_kwargs):
 
     def evaluate(event, client, logger):
         try:
-            handle_message_event(engine, client, event, cfg, nicks)
+            handle_message_event(engine, client, event, cfg, nicks, chat_log)
         except Exception:
             logger.exception("eval handler failed")
 

--- a/smeggdrop/platforms/slack.py
+++ b/smeggdrop/platforms/slack.py
@@ -68,11 +68,21 @@ SPECIAL_MENTION = re.compile(r"<!([a-z_]+)(?:\^[^|>]*)?(?:\|([^>]*))?>")
 
 
 def unfuck_slack_message(text: str) -> str:
-    """Undo slack's message mangling before trigger matching: unwrap
-    <url> / <url|label> links, unwrap a fully-backticked message, and
-    unescape html entities."""
-    text = re.sub(r"<(https?://[^|>]+)(?:\|[^>]*)?>", r"\1", text)
-    return html.unescape(unwrap_backticks(text))
+    """Undo slack's message mangling before trigger matching: unescape html
+    entities, unwrap <url> / <url|label> links, and unwrap a fully-
+    backticked message.
+
+    Unescaping has to happen first: slack sometimes delivers link markup
+    with the angle brackets as &lt;/&gt; entities (observed live — a user's
+    <http://x|x> arrived that way), and the url-unwrap regex needs real `<`
+    `>` characters to match. Getting this backwards doesn't leak anything
+    (SafeFetcher.validate rejects a URL with stray `<>` for an unrelated
+    reason — the scheme fails to parse), but it does mean a legitimately
+    pasted link in that form would break with a confusing error.
+    """
+    text = html.unescape(text)
+    text = unwrap_backticks(text)
+    return re.sub(r"<(https?://[^|>]+)(?:\|[^>]*)?>", r"\1", text)
 
 
 def unwrap_backticks(text: str) -> str:

--- a/smeggdrop/platforms/slack.py
+++ b/smeggdrop/platforms/slack.py
@@ -1,0 +1,191 @@
+"""Slack adapter: Events API on Lambda for prod, Socket Mode for dev.
+
+Wiring lives in build_app()/run_socket_mode() (the only places slack_bolt
+is imported); everything the adapter actually decides — trigger matching,
+message unmangling, reply formatting, the event handler — is plain code
+below, testable without the SDK.
+
+Slack-facing security:
+- request signatures are verified by bolt (signing secret); Socket Mode
+  needs no public endpoint at all
+- Events API retries are dropped by middleware: an eval can exceed Slack's
+  3s ack window, and a retried event must not re-run user code
+- everything in the message is untrusted input; it only ever reaches the
+  engine (which sandboxes it) and chat_postMessage as data
+"""
+
+from __future__ import annotations
+
+import html
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+
+from smeggdrop.engine import Engine, EvalRequest
+from smeggdrop.platforms import DEFAULT_TRIGGER, chunk_output, extract_code
+
+log = logging.getLogger(__name__)
+
+# stay under slack's 4k-chars-per-message recommendation, few messages max
+MAX_MESSAGE_CHARS = 3500
+MAX_MESSAGES = 3
+
+
+@dataclass
+class SlackConfig:
+    trigger: re.Pattern = DEFAULT_TRIGGER
+    channels: frozenset[str] = frozenset()  # empty = all channels
+    state_dir: str = "state"
+    time_limit: int = 5
+    words_file: str | None = None
+    app_token: str | None = None  # xapp-, socket mode only
+
+    @classmethod
+    def from_env(cls, env=os.environ) -> "SlackConfig":
+        channels = frozenset(
+            c.strip() for c in env.get("SMEGGDROP_CHANNELS", "").split(",") if c.strip()
+        )
+        return cls(
+            trigger=re.compile(env.get("SMEGGDROP_TRIGGER", DEFAULT_TRIGGER.pattern)),
+            channels=channels,
+            state_dir=env.get("SMEGGDROP_STATE", "state"),
+            time_limit=int(env.get("SMEGGDROP_TIME_LIMIT", "5")),
+            words_file=env.get("SMEGGDROP_WORDS") or None,
+            app_token=env.get("SLACK_APP_TOKEN") or None,
+        )
+
+
+def unfuck_slack_message(text: str) -> str:
+    """Undo slack's message mangling before trigger matching: unwrap
+    <url> / <url|label> links, unwrap a fully-backticked message, and
+    unescape html entities."""
+    text = re.sub(r"<(https?://[^|>]+)(?:\|[^>]*)?>", r"\1", text)
+    m = re.fullmatch(r"\s*`{1,3}(.+?)`{1,3}\s*", text, re.S)
+    if m:
+        text = m.group(1)
+    return html.unescape(text)
+
+
+def format_reply(ok: bool, output: str, warnings: list[str]) -> list[str]:
+    """Render an EvalResult as a list of slack messages (code blocks)."""
+    body = output if output else "(no output)"
+    if not ok:
+        body = f"error: {body}"
+    body = body.replace("```", "'''")
+    if warnings:
+        body += "\n" + "\n".join(f"warning: {w}" for w in warnings)
+
+    lines = chunk_output(body, max_chunk=MAX_MESSAGE_CHARS, max_chunks=MAX_MESSAGES * 50)
+    messages: list[str] = []
+    current = ""
+    for line in lines:
+        candidate = f"{current}\n{line}" if current else line
+        if len(candidate) > MAX_MESSAGE_CHARS:
+            messages.append(current)
+            current = line
+        else:
+            current = candidate
+    if current:
+        messages.append(current)
+    if len(messages) > MAX_MESSAGES:
+        messages = messages[:MAX_MESSAGES]
+        messages[-1] += "\n(truncated)"
+    return [f"```{m}```" for m in messages]
+
+
+class NickCache:
+    """user id -> display name via users.info, cached; falls back to the id."""
+
+    def __init__(self):
+        self._names: dict[str, str] = {}
+
+    def resolve(self, client, user_id: str) -> str:
+        if not user_id:
+            return "unknown"
+        if user_id not in self._names:
+            try:
+                info = client.users_info(user=user_id)
+                user = info["user"]
+                self._names[user_id] = (
+                    user.get("profile", {}).get("display_name")
+                    or user.get("name")
+                    or user_id
+                )
+            except Exception:
+                self._names[user_id] = user_id
+        return self._names[user_id]
+
+
+def handle_message_event(
+    engine: Engine, client, event: dict, cfg: SlackConfig, nicks: NickCache | None = None
+) -> bool:
+    """Process one message event. Returns True if an eval ran."""
+    subtype = event.get("subtype")
+    if subtype == "message_changed":
+        msg = event.get("message") or {}
+    elif subtype is None:
+        msg = event
+    else:
+        return False  # joins, topic changes, bot_message, etc.
+    if msg.get("bot_id") or msg.get("subtype"):
+        return False  # never evaluate our own (or any bot's) output
+
+    channel = event.get("channel") or ""
+    if cfg.channels and channel not in cfg.channels:
+        return False
+
+    text = msg.get("text") or ""
+    code = extract_code(unfuck_slack_message(text), cfg.trigger)
+    if code is None or not code.strip():
+        return False
+
+    user_id = msg.get("user") or ""
+    nick = (nicks or NickCache()).resolve(client, user_id) if user_id else msg.get("username", "unknown")
+    log.info("eval from %s in %s: %r", nick, channel, code[:120])
+
+    result = engine.eval(
+        EvalRequest(code=code, nick=nick, channel=channel, mask=user_id or None),
+        say=lambda t: client.chat_postMessage(channel=channel, text=t),
+    )
+    for message in format_reply(result.ok, result.output, result.warnings):
+        client.chat_postMessage(channel=channel, text=message)
+    return True
+
+
+def build_app(engine: Engine, cfg: SlackConfig, **app_kwargs):
+    """Bolt app wired for FaaS: ack within 3s, eval in a lazy listener."""
+    from slack_bolt import App
+
+    app = App(process_before_response=True, **app_kwargs)
+    nicks = NickCache()
+
+    @app.middleware
+    def drop_retries(request, next):
+        # a retried delivery means our ack was slow, not that the eval
+        # didn't happen; re-running user code is worse than dropping
+        if request.headers.get("x-slack-retry-num"):
+            return
+        next()
+
+    def ack_only(ack):
+        ack()
+
+    def evaluate(event, client, logger):
+        try:
+            handle_message_event(engine, client, event, cfg, nicks)
+        except Exception:
+            logger.exception("eval handler failed")
+
+    app.event("message")(ack=ack_only, lazy=[evaluate])
+    return app
+
+
+def run_socket_mode(engine: Engine, cfg: SlackConfig) -> None:
+    from slack_bolt.adapter.socket_mode import SocketModeHandler
+
+    if not cfg.app_token:
+        raise SystemExit("SLACK_APP_TOKEN (xapp-...) is required for socket mode")
+    app = build_app(engine, cfg)
+    log.info("starting socket mode")
+    SocketModeHandler(app, cfg.app_token).start()

--- a/smeggdrop/platforms/slack.py
+++ b/smeggdrop/platforms/slack.py
@@ -38,6 +38,7 @@ MAX_MESSAGES = 3
 class SlackConfig:
     trigger: re.Pattern = DEFAULT_TRIGGER
     channels: frozenset[str] = frozenset()  # empty = all channels
+    blocked_users: frozenset[str] = frozenset()  # slack user IDs, not names
     state_dir: str = "state"
     time_limit: int = 5
     words_file: str | None = None
@@ -48,12 +49,16 @@ class SlackConfig:
         channels = frozenset(
             c.strip() for c in env.get("SMEGGDROP_CHANNELS", "").split(",") if c.strip()
         )
+        blocked_users = frozenset(
+            u.strip() for u in env.get("SMEGGDROP_BLOCKED_USERS", "").split(",") if u.strip()
+        )
         return cls(
             # case-insensitive like the default: chat clients capitalize
             trigger=re.compile(
                 env.get("SMEGGDROP_TRIGGER", DEFAULT_TRIGGER.pattern), re.IGNORECASE
             ),
             channels=channels,
+            blocked_users=blocked_users,
             state_dir=env.get("SMEGGDROP_STATE", "state"),
             time_limit=int(env.get("SMEGGDROP_TIME_LIMIT", "5")),
             words_file=env.get("SMEGGDROP_WORDS") or None,
@@ -286,6 +291,11 @@ def handle_message_event(
 
     channel = event.get("channel") or ""
     if cfg.channels and channel not in cfg.channels:
+        return False
+
+    # keyed on the immutable slack user id, never on nick/display name
+    # (which is user-controlled and can be changed or duplicated)
+    if (msg.get("user") or "") in cfg.blocked_users:
         return False
 
     text = msg.get("text") or ""

--- a/smeggdrop/platforms/slack.py
+++ b/smeggdrop/platforms/slack.py
@@ -48,7 +48,10 @@ class SlackConfig:
             c.strip() for c in env.get("SMEGGDROP_CHANNELS", "").split(",") if c.strip()
         )
         return cls(
-            trigger=re.compile(env.get("SMEGGDROP_TRIGGER", DEFAULT_TRIGGER.pattern)),
+            # case-insensitive like the default: chat clients capitalize
+            trigger=re.compile(
+                env.get("SMEGGDROP_TRIGGER", DEFAULT_TRIGGER.pattern), re.IGNORECASE
+            ),
             channels=channels,
             state_dir=env.get("SMEGGDROP_STATE", "state"),
             time_limit=int(env.get("SMEGGDROP_TIME_LIMIT", "5")),

--- a/smeggdrop/platforms/slack.py
+++ b/smeggdrop/platforms/slack.py
@@ -67,8 +67,19 @@ def unfuck_slack_message(text: str) -> str:
     return html.unescape(text)
 
 
+# mIRC formatting: bold/underline/reset/reverse, and colour (^C plus up to
+# two digits, optionally ,digits). Slack renders none of it, and the digits
+# show up as literal garbage in the middle of ascii art if left in.
+IRC_FORMATTING = re.compile(r"[\x02\x1d\x1f\x0f\x16]|\x03\d{0,2}(?:,\d{1,2})?")
+
+
+def strip_irc_formatting(text: str) -> str:
+    return IRC_FORMATTING.sub("", text)
+
+
 def format_reply(ok: bool, output: str, warnings: list[str]) -> list[str]:
     """Render an EvalResult as a list of slack messages (code blocks)."""
+    output = strip_irc_formatting(output)
     body = output if output else "(no output)"
     if not ok:
         body = f"error: {body}"
@@ -117,6 +128,30 @@ class NickCache:
         return self._names[user_id]
 
 
+class ChannelCache:
+    """channel id -> #name via conversations.info, cached.
+
+    Saved procs treat [channel] as an irc channel name (they print it, and
+    they key cache buckets off it), so the sandbox sees "#tcl" while the
+    api calls keep using the id. Falls back to the id.
+    """
+
+    def __init__(self):
+        self._names: dict[str, str] = {}
+
+    def resolve(self, client, channel_id: str) -> str:
+        if not channel_id:
+            return ""
+        if channel_id not in self._names:
+            try:
+                info = client.conversations_info(channel=channel_id)
+                name = info["channel"].get("name")
+                self._names[channel_id] = f"#{name}" if name else channel_id
+            except Exception:
+                self._names[channel_id] = channel_id
+        return self._names[channel_id]
+
+
 def handle_message_event(
     engine: Engine,
     client,
@@ -124,6 +159,7 @@ def handle_message_event(
     cfg: SlackConfig,
     nicks: NickCache | None = None,
     chat_log: ChatLog | None = None,
+    channels: ChannelCache | None = None,
 ) -> bool:
     """Process one message event. Returns True if an eval ran."""
     subtype = event.get("subtype")
@@ -150,16 +186,19 @@ def handle_message_event(
             chat_log.append(channel, nick, user_id or None, text)
         return False
 
-    log.info("eval from %s in %s: %r", nick, channel, code[:120])
+    channel_name = (channels or ChannelCache()).resolve(client, channel)
+    log.info("eval from %s in %s: %r", nick, channel_name, code[:120])
     result = engine.eval(
         EvalRequest(
             code=code,
             nick=nick,
-            channel=channel,
+            channel=channel_name,
             mask=user_id or None,
             loglines=chat_log.slurp(channel) if chat_log is not None else (),
         ),
-        say=lambda t: client.chat_postMessage(channel=channel, text=t),
+        say=lambda t: client.chat_postMessage(
+            channel=channel, text=strip_irc_formatting(t)
+        ),
     )
     for message in format_reply(result.ok, result.output, result.warnings):
         client.chat_postMessage(channel=channel, text=message)
@@ -172,6 +211,7 @@ def build_app(engine: Engine, cfg: SlackConfig, **app_kwargs):
 
     app = App(process_before_response=True, **app_kwargs)
     nicks = NickCache()
+    channels = ChannelCache()
     chat_log = ChatLog()
 
     @app.middleware
@@ -187,7 +227,7 @@ def build_app(engine: Engine, cfg: SlackConfig, **app_kwargs):
 
     def evaluate(event, client, logger):
         try:
-            handle_message_event(engine, client, event, cfg, nicks, chat_log)
+            handle_message_event(engine, client, event, cfg, nicks, chat_log, channels)
         except Exception:
             logger.exception("eval handler failed")
 

--- a/smeggdrop/platforms/slack.py
+++ b/smeggdrop/platforms/slack.py
@@ -20,6 +20,7 @@ import html
 import logging
 import os
 import re
+import time
 from collections import OrderedDict
 from dataclasses import dataclass
 
@@ -307,17 +308,68 @@ def handle_message_event(
     return True
 
 
+POST_ATTEMPTS = 3
+POST_BACKOFF_SECONDS = 0.5
+
+
 def post(client, channel: str, text: str):
     """Post eval output. Everything here is attacker-influenced, so slack is
-    told not to linkify, unfurl, or resolve names in it."""
-    return client.chat_postMessage(
-        channel=channel,
-        text=text,
-        parse="none",
-        link_names=False,
-        unfurl_links=False,
-        unfurl_media=False,
-    )
+    told not to linkify, unfurl, or resolve names in it.
+
+    Retries transient failures: a TLS handshake timeout or a rate limit
+    here means the eval ran but its answer never arrived, which reads in
+    channel as the bot ignoring you.
+    """
+    delay = POST_BACKOFF_SECONDS
+    for attempt in range(1, POST_ATTEMPTS + 1):
+        try:
+            return client.chat_postMessage(
+                channel=channel,
+                text=text,
+                parse="none",
+                link_names=False,
+                unfurl_links=False,
+                unfurl_media=False,
+            )
+        except Exception as e:  # noqa: BLE001 — sdk raises several types
+            if attempt == POST_ATTEMPTS or not is_transient(e):
+                raise
+            wait = retry_after_seconds(e) or delay
+            log.warning("post failed (%s), retrying in %.1fs", e, wait)
+            time.sleep(wait)
+            delay *= 2
+
+
+TRANSIENT_MARKERS = (
+    "timed out",
+    "timeout",
+    "connection",
+    "handshake",
+    "temporarily unavailable",
+    "ratelimited",
+    "rate limited",
+    "server_error",
+    "service_unavailable",
+    "internal_error",
+)
+
+
+def is_transient(error: Exception) -> bool:
+    status = getattr(getattr(error, "response", None), "status_code", None)
+    if status is not None and (status == 429 or status >= 500):
+        return True
+    return any(m in str(error).lower() for m in TRANSIENT_MARKERS)
+
+
+def retry_after_seconds(error: Exception) -> float | None:
+    headers = getattr(getattr(error, "response", None), "headers", None) or {}
+    raw = headers.get("Retry-After") or headers.get("retry-after")
+    if isinstance(raw, (list, tuple)):
+        raw = raw[0] if raw else None
+    try:
+        return float(raw) if raw is not None else None
+    except (TypeError, ValueError):
+        return None
 
 
 def summarize(text: str, limit: int = 160) -> str:

--- a/smeggdrop/platforms/slack.py
+++ b/smeggdrop/platforms/slack.py
@@ -56,6 +56,12 @@ class SlackConfig:
         )
 
 
+USER_MENTION = re.compile(r"<@([UW][A-Z0-9]+)(?:\|([^>]*))?>")
+CHANNEL_MENTION = re.compile(r"<#[C][A-Z0-9]+(?:\|([^>]*))?>")
+BROADCAST_MENTION = re.compile(r"<!(here|channel|everyone)(?:\|[^>]*)?>")
+SPECIAL_MENTION = re.compile(r"<!([a-z_]+)(?:\^[^|>]*)?(?:\|([^>]*))?>")
+
+
 def unfuck_slack_message(text: str) -> str:
     """Undo slack's message mangling before trigger matching: unwrap
     <url> / <url|label> links, unwrap a fully-backticked message, and
@@ -65,6 +71,37 @@ def unfuck_slack_message(text: str) -> str:
     if m:
         text = m.group(1)
     return html.unescape(text)
+
+
+def resolve_mentions(text: str, client, nicks: "NickCache") -> str:
+    """Turn slack mention syntax into the plain nicks procs expect.
+
+    The saved procs were written for irc, where `deathto winkie` gets the
+    literal nick. Slack delivers `deathto <@U123>`, which procs then echo
+    back verbatim — unreadable, and it re-pings the target.
+    """
+    text = USER_MENTION.sub(
+        lambda m: m.group(2) or nicks.resolve(client, m.group(1)), text
+    )
+    text = CHANNEL_MENTION.sub(lambda m: f"#{m.group(1)}" if m.group(1) else "#channel", text)
+    text = BROADCAST_MENTION.sub(lambda m: m.group(1), text)
+    return SPECIAL_MENTION.sub(lambda m: m.group(2) or m.group(1), text)
+
+
+def defang_mentions(text: str) -> str:
+    """Neutralize anything in outgoing text that slack would turn into a
+    notification.
+
+    Otherwise the bot is a ping cannon: `tcl . <!channel> wake up` (or a
+    saved proc that stores mention markup) would notify an entire
+    workspace on demand, as many times as someone cares to ask. Code
+    fences alone are not a guarantee, so strip the syntax itself and post
+    with parse=none as well.
+    """
+    text = BROADCAST_MENTION.sub(lambda m: f"@​{m.group(1)}", text)
+    text = USER_MENTION.sub(lambda m: f"@​{m.group(2) or m.group(1)}", text)
+    text = CHANNEL_MENTION.sub(lambda m: f"#​{m.group(1) or 'channel'}", text)
+    return SPECIAL_MENTION.sub(lambda m: f"@​{m.group(2) or m.group(1)}", text)
 
 
 # mIRC formatting: bold/underline/reset/reverse, and colour (^C plus up to
@@ -79,7 +116,7 @@ def strip_irc_formatting(text: str) -> str:
 
 def format_reply(ok: bool, output: str, warnings: list[str]) -> list[str]:
     """Render an EvalResult as a list of slack messages (code blocks)."""
-    output = strip_irc_formatting(output)
+    output = defang_mentions(strip_irc_formatting(output))
     body = output if output else "(no output)"
     if not ok:
         body = f"error: {body}"
@@ -103,6 +140,24 @@ def format_reply(ok: bool, output: str, warnings: list[str]) -> list[str]:
         messages = messages[:MAX_MESSAGES]
         messages[-1] += "\n(truncated)"
     return [f"```{m}```" for m in messages]
+
+
+def retry_attempt(headers) -> int:
+    """Slack's retry counter: 0 (or absent) on first delivery, >=1 on retry.
+
+    Bolt stores header values as lists, and Socket Mode synthesizes the
+    header from the envelope's retry_attempt, so it is present even when
+    nothing has been retried.
+    """
+    raw = (headers or {}).get("x-slack-retry-num")
+    if isinstance(raw, (list, tuple)):
+        raw = raw[0] if raw else None
+    if raw is None or raw == "":
+        return 0
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return 0
 
 
 class NickCache:
@@ -178,12 +233,14 @@ def handle_message_event(
 
     text = msg.get("text") or ""
     user_id = msg.get("user") or ""
-    nick = (nicks or NickCache()).resolve(client, user_id) if user_id else msg.get("username", "unknown")
+    resolver = nicks or NickCache()
+    nick = resolver.resolve(client, user_id) if user_id else msg.get("username", "unknown")
 
-    code = extract_code(unfuck_slack_message(text), cfg.trigger)
+    cleaned = resolve_mentions(unfuck_slack_message(text), client, resolver)
+    code = extract_code(cleaned, cfg.trigger)
     if code is None or not code.strip():
-        if chat_log is not None and text:
-            chat_log.append(channel, nick, user_id or None, text)
+        if chat_log is not None and cleaned:
+            chat_log.append(channel, nick, user_id or None, cleaned)
         return False
 
     channel_name = (channels or ChannelCache()).resolve(client, channel)
@@ -196,34 +253,68 @@ def handle_message_event(
             mask=user_id or None,
             loglines=chat_log.slurp(channel) if chat_log is not None else (),
         ),
-        say=lambda t: client.chat_postMessage(
-            channel=channel, text=strip_irc_formatting(t)
-        ),
+        say=lambda t: post(client, channel, defang_mentions(strip_irc_formatting(t))),
     )
+    # log the outcome, not just the input: an operator (or whoever is
+    # babysitting a fresh deploy) needs to see which evals are failing and
+    # what the sandbox refused, without reading the channel
+    if result.ok:
+        log.info("eval ok for %s: %s", nick, summarize(result.output))
+    else:
+        log.warning("eval error for %s: %s -> %s", nick, code[:80], summarize(result.output))
+    for warning in result.warnings:
+        log.warning("eval warning for %s: %s", nick, warning)
+
     for message in format_reply(result.ok, result.output, result.warnings):
-        client.chat_postMessage(channel=channel, text=message)
+        post(client, channel, message)
     return True
 
 
-def build_app(engine: Engine, cfg: SlackConfig, **app_kwargs):
-    """Bolt app wired for FaaS: ack within 3s, eval in a lazy listener."""
+def post(client, channel: str, text: str):
+    """Post eval output. Everything here is attacker-influenced, so slack is
+    told not to linkify, unfurl, or resolve names in it."""
+    return client.chat_postMessage(
+        channel=channel,
+        text=text,
+        parse="none",
+        link_names=False,
+        unfurl_links=False,
+        unfurl_media=False,
+    )
+
+
+def summarize(text: str, limit: int = 160) -> str:
+    """One-line, length-capped rendering of eval output for logs."""
+    flat = " ".join(strip_irc_formatting(text or "").split())
+    return flat[:limit] + ("..." if len(flat) > limit else "")
+
+
+def build_app(engine: Engine, cfg: SlackConfig, *, lazy: bool = False, **app_kwargs):
+    """Build the bolt app.
+
+    lazy=True is the FaaS wiring: ack inside slack's 3s window, then do the
+    eval in a lazy listener, which on Lambda means a second invocation of
+    the function. Off FaaS that machinery buys nothing (bolt just runs the
+    lazy listener in its thread pool), so the socket-mode path registers an
+    ordinary listener and lets bolt ack before running it.
+    """
     from slack_bolt import App
 
-    app = App(process_before_response=True, **app_kwargs)
+    app = App(process_before_response=lazy, **app_kwargs)
     nicks = NickCache()
     channels = ChannelCache()
     chat_log = ChatLog()
 
     @app.middleware
     def drop_retries(request, next):
-        # a retried delivery means our ack was slow, not that the eval
-        # didn't happen; re-running user code is worse than dropping
-        if request.headers.get("x-slack-retry-num"):
+        # A retried delivery means our ack was slow, not that the eval
+        # didn't happen; re-running user code is worse than dropping.
+        # The header is present on FIRST delivery too, valued 0 — testing
+        # for presence alone silently drops every single message.
+        if retry_attempt(request.headers) > 0:
+            log.info("dropping retried delivery")
             return
         next()
-
-    def ack_only(ack):
-        ack()
 
     def evaluate(event, client, logger):
         try:
@@ -231,7 +322,10 @@ def build_app(engine: Engine, cfg: SlackConfig, **app_kwargs):
         except Exception:
             logger.exception("eval handler failed")
 
-    app.event("message")(ack=ack_only, lazy=[evaluate])
+    if lazy:
+        app.event("message")(ack=lambda ack: ack(), lazy=[evaluate])
+    else:
+        app.event("message")(evaluate)
     return app
 
 

--- a/smeggdrop/platforms/slack.py
+++ b/smeggdrop/platforms/slack.py
@@ -72,10 +72,19 @@ def unfuck_slack_message(text: str) -> str:
     <url> / <url|label> links, unwrap a fully-backticked message, and
     unescape html entities."""
     text = re.sub(r"<(https?://[^|>]+)(?:\|[^>]*)?>", r"\1", text)
-    m = re.fullmatch(r"\s*`{1,3}(.+?)`{1,3}\s*", text, re.S)
-    if m:
-        text = m.group(1)
-    return html.unescape(text)
+    return html.unescape(unwrap_backticks(text))
+
+
+def unwrap_backticks(text: str) -> str:
+    """Strip backticks that wrap the whole string.
+
+    People copy commands out of code-formatted messages, so `tcl ``snoe``
+    arrives with the code portion still fenced and fails as an invalid
+    command name. Only unwrap when the fences enclose everything — a stray
+    backtick inside real tcl is left alone.
+    """
+    match = re.fullmatch(r"\s*`{1,3}([^`].*?)`{1,3}\s*", text, re.S)
+    return match.group(1) if match else text
 
 
 def resolve_mentions(text: str, client, nicks: "NickCache") -> str:
@@ -276,6 +285,9 @@ def handle_message_event(
 
     cleaned = resolve_mentions(unfuck_slack_message(text), client, resolver)
     code = extract_code(cleaned, cfg.trigger)
+    if code is not None:
+        # the trigger may have been outside the fences: "tcl `snoe`"
+        code = unwrap_backticks(code)
     if code is None or not code.strip():
         if chat_log is not None and cleaned:
             chat_log.append(channel, nick, user_id or None, cleaned)

--- a/smeggdrop/security.py
+++ b/smeggdrop/security.py
@@ -37,6 +37,7 @@ class FetchError(Exception):
 class FetchPolicy:
     timeout: float = 10.0
     max_bytes: int = 1_000_000
+    max_post_bytes: int = 150_000  # same default the old http.tcl enforced
     max_redirects: int = 3
     allowed_schemes: frozenset[str] = frozenset({"http", "https"})
     # tests and local dev only; never enable where an internal network exists
@@ -53,12 +54,23 @@ class SafeFetcher:
         self.policy = policy or FetchPolicy()
         self._opener = urllib.request.build_opener(_NoRedirect())
 
-    def fetch(self, url: str) -> tuple[int, str]:
-        """GET a URL. Returns (status, body). Raises FetchError on refusal."""
+    def fetch(
+        self, url: str, method: str = "GET", body: str | None = None
+    ) -> tuple[int, dict[str, str], str]:
+        """Request a URL. Returns (status, headers, body). Raises FetchError
+        on refusal. Only GET/HEAD/POST; POST bodies are size-capped."""
+        method = method.upper()
+        if method not in ("GET", "HEAD", "POST"):
+            raise FetchError(f"refusing method {method!r}")
+        data = None
+        if method == "POST":
+            data = (body or "").encode("utf-8")
+            if len(data) > self.policy.max_post_bytes:
+                raise FetchError(f"post body exceeds {self.policy.max_post_bytes} bytes")
         for _ in range(self.policy.max_redirects + 1):
             self.validate(url)
             req = urllib.request.Request(
-                url, headers={"User-Agent": USER_AGENT}, method="GET"
+                url, data=data, headers={"User-Agent": USER_AGENT}, method=method
             )
             try:
                 resp = self._opener.open(req, timeout=self.policy.timeout)
@@ -68,16 +80,19 @@ class SafeFetcher:
                 raise FetchError(f"fetch failed: {getattr(e, 'reason', e)}") from e
             with resp:
                 status = resp.status if resp.status is not None else 0
+                headers = dict(resp.headers.items())
                 if status in REDIRECT_CODES:
                     location = resp.headers.get("Location")
                     if not location:
-                        return status, ""
+                        return status, headers, ""
                     url = urljoin(url, location)
+                    if status == 303:
+                        method, data = "GET", None
                     continue
-                body = resp.read(self.policy.max_bytes + 1)
-            if len(body) > self.policy.max_bytes:
-                body = body[: self.policy.max_bytes]
-            return status, body.decode("utf-8", "replace")
+                raw = resp.read(self.policy.max_bytes + 1)
+            if len(raw) > self.policy.max_bytes:
+                raw = raw[: self.policy.max_bytes]
+            return status, headers, raw.decode("utf-8", "replace")
         raise FetchError(f"too many redirects (>{self.policy.max_redirects})")
 
     def validate(self, url: str) -> None:

--- a/smeggdrop/state.py
+++ b/smeggdrop/state.py
@@ -38,6 +38,15 @@ def name_sha1(name: str) -> str:
     return hashlib.sha1(name.encode("utf-8")).hexdigest()
 
 
+def open_store(location: str) -> StateStore:
+    """Open a state store from a path or an s3:// uri."""
+    if location.startswith("s3://"):
+        from smeggdrop.state_s3 import S3StateStore
+
+        return S3StateStore.from_uri(location)
+    return FileStateStore(location)
+
+
 class FileStateStore:
     def __init__(self, root: Path | str):
         self.root = Path(root)

--- a/smeggdrop/state.py
+++ b/smeggdrop/state.py
@@ -38,6 +38,22 @@ def name_sha1(name: str) -> str:
     return hashlib.sha1(name.encode("utf-8")).hexdigest()
 
 
+def decode(data: bytes) -> str:
+    """Decode saved state, tolerating the perl bot's raw bytes.
+
+    That implementation used `use bytes` and wrote whatever came off irc, so
+    a handful of procs hold latin-1: `¯`·.¸¸.·´¯` wave decorations, `°_o`
+    faces, the odd accented word. Decoding those with errors="replace"
+    silently turns each one into U+FFFD and destroys the art — it showed up
+    as `<?>_o` in okeybattle. latin-1 maps every byte to a codepoint, so it
+    is a lossless fallback; anything written from here on is utf-8.
+    """
+    try:
+        return data.decode("utf-8")
+    except UnicodeDecodeError:
+        return data.decode("latin-1")
+
+
 def open_store(location: str) -> StateStore:
     """Open a state store from a path or an s3:// uri."""
     if location.startswith("s3://"):
@@ -61,7 +77,7 @@ class FileStateStore:
         for name, sha in index.items():
             path = self.root / category / sha
             try:
-                data = path.read_text(encoding="utf-8", errors="replace")
+                data = decode(path.read_bytes())
             except FileNotFoundError:
                 # damage, not deletion — keep the entry so the loss stays
                 # visible (and recoverable if the file turns up)
@@ -95,7 +111,7 @@ class FileStateStore:
         if not path.exists():
             return {}
         index: dict[str, str] = {}
-        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        for line in decode(path.read_bytes()).splitlines():
             line = line.strip()
             if not line:
                 continue

--- a/smeggdrop/state_s3.py
+++ b/smeggdrop/state_s3.py
@@ -1,0 +1,159 @@
+"""S3-backed state, for running on Lambda.
+
+The file layout stores one object per proc, which is fine on a disk and
+terrible against an object store: 6,600 GETs on every cold start. The whole
+hardchats state is only ~6 MB of actual content, so each category is packed
+into a single JSON object instead — one GET to load, one PUT per eval that
+changes anything.
+
+History comes from S3 bucket versioning rather than from keeping old
+objects around: turn it on and every eval's state becomes a restorable
+version.
+
+Concurrent writers are handled with a conditional PUT (If-Match on the
+ETag we loaded). If another process wrote in between, this reloads, re-
+applies its own changes on top, and retries — so a second Lambda container
+can't silently clobber a proc someone just defined. Run with reserved
+concurrency 1 anyway; this is the backstop, not the plan.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Mapping
+
+log = logging.getLogger(__name__)
+
+CATEGORIES = ("procs", "vars")
+PUT_ATTEMPTS = 5
+
+
+class S3StateStore:
+    def __init__(self, bucket: str, prefix: str = "", client=None):
+        self.bucket = bucket
+        self.prefix = prefix.strip("/")
+        self._client = client
+        self._snapshots: dict[str, dict[str, str]] = {}
+        self._etags: dict[str, str | None] = {}
+
+    @classmethod
+    def from_uri(cls, uri: str, client=None) -> "S3StateStore":
+        """s3://bucket/optional/prefix"""
+        if not uri.startswith("s3://"):
+            raise ValueError(f"not an s3 uri: {uri!r}")
+        bucket, _, prefix = uri[len("s3://") :].partition("/")
+        if not bucket:
+            raise ValueError(f"no bucket in {uri!r}")
+        return cls(bucket, prefix, client=client)
+
+    @property
+    def client(self):
+        if self._client is None:
+            import boto3  # imported lazily so the core stays dependency-free
+
+            self._client = boto3.client("s3")
+        return self._client
+
+    def key(self, category: str) -> str:
+        return f"{self.prefix}/{category}.json" if self.prefix else f"{category}.json"
+
+    # -- StateStore protocol -------------------------------------------
+
+    def load(self, category: str) -> dict[str, str]:
+        snapshot, etag = self._fetch(category)
+        self._snapshots[category] = snapshot
+        self._etags[category] = etag
+        return dict(snapshot)
+
+    def save_many(self, category: str, changes: Mapping[str, str | None]) -> None:
+        if not changes:
+            return
+        for attempt in range(1, PUT_ATTEMPTS + 1):
+            snapshot = dict(self._snapshots.get(category, {}))
+            _apply(snapshot, changes)
+            try:
+                etag = self._put(category, snapshot, self._etags.get(category))
+            except _Conflict:
+                # somebody else wrote; take their version and re-apply ours
+                log.warning("%s: state changed underneath us, merging", category)
+                fresh, fresh_etag = self._fetch(category)
+                self._snapshots[category] = fresh
+                self._etags[category] = fresh_etag
+                if attempt == PUT_ATTEMPTS:
+                    raise
+                continue
+            self._snapshots[category] = snapshot
+            self._etags[category] = etag
+            return
+
+    # -- s3 plumbing ----------------------------------------------------
+
+    def _fetch(self, category: str) -> tuple[dict[str, str], str | None]:
+        try:
+            response = self.client.get_object(Bucket=self.bucket, Key=self.key(category))
+        except Exception as e:  # noqa: BLE001 — botocore raises dynamic classes
+            if _is_missing(e):
+                return {}, None
+            raise
+        body = response["Body"].read()
+        etag = response.get("ETag")
+        if not body:
+            return {}, etag
+        return json.loads(body.decode("utf-8")), etag
+
+    def _put(self, category: str, snapshot: dict[str, str], etag: str | None) -> str | None:
+        body = json.dumps(snapshot, ensure_ascii=False, sort_keys=True).encode("utf-8")
+        kwargs = {
+            "Bucket": self.bucket,
+            "Key": self.key(category),
+            "Body": body,
+            "ContentType": "application/json",
+        }
+        conditional = dict(kwargs)
+        if etag:
+            conditional["IfMatch"] = etag
+        else:
+            conditional["IfNoneMatch"] = "*"  # create-only, don't clobber
+        try:
+            response = self.client.put_object(**conditional)
+        except Exception as e:  # noqa: BLE001
+            if _is_precondition_failed(e):
+                raise _Conflict from e
+            if not _is_unsupported_parameter(e):
+                raise
+            # older botocore, or a store without conditional writes: fall
+            # back to an unconditional put and rely on single-writer
+            log.warning("conditional put unsupported; writing unconditionally")
+            response = self.client.put_object(**kwargs)
+        return response.get("ETag")
+
+
+class _Conflict(Exception):
+    pass
+
+
+def _apply(snapshot: dict[str, str], changes: Mapping[str, str | None]) -> None:
+    for name, value in changes.items():
+        if value is None:
+            snapshot.pop(name, None)
+        else:
+            snapshot[name] = value
+
+
+def _error_code(error: Exception) -> str:
+    response = getattr(error, "response", None) or {}
+    return str(response.get("Error", {}).get("Code", ""))
+
+
+def _is_missing(error: Exception) -> bool:
+    return _error_code(error) in ("NoSuchKey", "404", "NotFound")
+
+
+def _is_precondition_failed(error: Exception) -> bool:
+    return _error_code(error) in ("PreconditionFailed", "412", "ConditionalRequestConflict")
+
+
+def _is_unsupported_parameter(error: Exception) -> bool:
+    name = type(error).__name__
+    return name in ("ParamValidationError", "ClientError") and "IfMatch" in str(error)

--- a/smeggdrop/tcl/bootstrap.tcl
+++ b/smeggdrop/tcl/bootstrap.tcl
@@ -16,7 +16,14 @@ proc log {} {return $context::log}
 
 # best-effort: the old hostmask proc looked nicks up in channel state,
 # which chat platforms don't have; fall back to scanning recent chatter
-proc hostmask {who} {
+# regression found live: remote_command_state calls this bare (no
+# argument) expecting the caller's own hostmask, matching the old
+# eggdrop/irc idiom -- default empty/omitted to [nick], same "no target
+# means self" convention as the name proc.
+proc hostmask {{who {}}} {
+    if {$who eq ""} {
+        set who [nick]
+    }
     foreach line [log] {
         lassign $line _ts _nick _mask _text
         if {[string equal -nocase $_nick $who]} {return $_mask}

--- a/smeggdrop/tcl/bootstrap.tcl
+++ b/smeggdrop/tcl/bootstrap.tcl
@@ -35,6 +35,38 @@ proc interp_eval {script} {
     uplevel #0 $script
 }
 
+# [apply] means two different things in the saved state.
+#
+# Tcl 8.5 introduced a builtin taking a lambda: [apply {{x} {body}} arg].
+# Saved procs like map/select/cseq use that. But smeggdrop also had its own
+# [apply] meaning "run this command with this argument list":
+# [apply {format %s-%s} {a b}], and procs like yield use *that*. Whichever
+# one is installed, the other convention's callers break — which is what
+# made cseq (and everything built on it) fail.
+#
+# The builtin is stashed as tcl_apply before any of this loads (see
+# interp.py). Dispatch on the shape of the first argument: a lambda's first
+# element is an argument list, so it does not name an existing command,
+# while the classic form's does. The heuristic can be fooled, hence the
+# fallback.
+proc apply {cmd args} {
+    if {([llength $cmd] == 2 || [llength $cmd] == 3)
+            && ![llength [info commands [lindex $cmd 0]]]} {
+        return [uplevel 1 [linsert $args 0 tcl_apply $cmd]]
+    }
+    # {*} so the classic form keeps concat's flattening: [apply {format %s-%s}
+    # {a b}] must run "format %s-%s a b", not pass {a b} as one argument
+    if {[catch {uplevel 1 [concat $cmd {*}$args]} result options]} {
+        if {[llength $cmd] == 2 || [llength $cmd] == 3} {
+            if {![catch {uplevel 1 [linsert $args 0 tcl_apply $cmd]} alternate]} {
+                return $alternate
+            }
+        }
+        return -options $options $result
+    }
+    return $result
+}
+
 namespace eval commands {
     proc words {} { core::words }
 }

--- a/smeggdrop/tcl/bootstrap.tcl
+++ b/smeggdrop/tcl/bootstrap.tcl
@@ -8,9 +8,31 @@ proc mask {} {return $context::mask}
 proc command {} {return $context::command}
 proc nicks {} {return $context::nicks}
 
+# irc-era accessors a lot of saved procs rely on
+proc names {} {return $context::nicks}
+
+# recent channel chatter as {unix_ts nick mask text} rows
+proc log {} {return $context::log}
+
+# best-effort: the old hostmask proc looked nicks up in channel state,
+# which chat platforms don't have; fall back to scanning recent chatter
+proc hostmask {who} {
+    foreach line [log] {
+        lassign $line _ts _nick _mask _text
+        if {[string equal -nocase $_nick $who]} {return $_mask}
+    }
+    return "$who!unknown@unknown"
+}
+
 # some saved procs use [alias] to publish namespaced procs as global names
 proc alias {name target} {
     interp alias {} $name {} $target
+}
+
+# the old versioned interpreter exposed this; cache::fetch et al use it to
+# evaluate a script at interpreter (global) level
+proc interp_eval {script} {
+    uplevel #0 $script
 }
 
 namespace eval commands {

--- a/smeggdrop/tcl/httpx.tcl
+++ b/smeggdrop/tcl/httpx.tcl
@@ -1,0 +1,34 @@
+# http compat for saved procs, same interface as the tclcurl-era http.tcl:
+#   http get $url            -> [list code {header value ...} body]
+#   http post $url $body ?k v ...?
+#   http head $url           -> {header value ...}
+# backed by the host's guarded fetcher (core::http), which enforces the
+# scheme/address policy and per-eval limits.
+
+namespace eval httpx {
+  proc get url {
+    core::http GET $url
+  }
+
+  proc post {url body args} {
+    if {[llength $args]} {
+      # legacy form: post url k v ?k v ...? url-encodes pairs ($body is
+      # the first key, like http::formatQuery did)
+      set pairs [linsert $args 0 $body]
+      set enc [list]
+      foreach {k v} $pairs {
+        lappend enc "[core::urlencode $k]=[core::urlencode $v]"
+      }
+      set body [join $enc &]
+    }
+    core::http POST $url $body
+  }
+
+  proc head url {
+    lindex [core::http HEAD $url] 1
+  }
+}
+
+namespace eval commands {
+  meta_proc http -namespace httpx head get post
+}

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -18,6 +18,9 @@ def store(tmp_path):
             "with_args": "{a b} {expr {$a + $b}}",
             "defaulted": '{{who world}} {return "hi $who"}',
             "wont_load": "{} {return {unbalanced",
+            # bootstrap aliases `cache` globally after state load, hiding this
+            "cache": "{} {return stale}",
+            "fetches": "{} {http get http://example.com/}",
         },
     )
     s.save_many("vars", {"ok_var": "scalar {1}", "bad_var": "bogus {1}"})
@@ -51,6 +54,15 @@ def test_audit_full_report(store):
     assert not procs["wont_load"].loaded
     assert procs["wont_load"].load_error
 
+    # shadowed by the bootstrap alias, not scanned or run, doesn't crash
+    assert procs["cache"].shadowed
+    assert not procs["cache"].ran
+
+    # reached the (stubbed) network: working proc, not a failure
+    assert procs["fetches"].needs_network
+    assert procs["fetches"].run_ok is None
+    assert procs["fetches"].healthy
+
     assert "bad_var" in report.var_load_errors
     assert "ok_var" not in report.var_load_errors
 
@@ -58,8 +70,10 @@ def test_audit_full_report(store):
 def test_audit_summary_counts(store):
     report = audit_state(store)
     summary = report.summary()
-    assert summary["total"] == 6
+    assert summary["total"] == 8
     assert summary["load_failures"] == 1
+    assert summary["shadowed"] == 1
+    assert summary["needs_network"] == 1
     assert summary["broken_refs"] == 1
     assert summary["run_failures"] == 2
     assert summary["var_load_failures"] == 1

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -105,3 +105,34 @@ def test_audit_never_writes_state(store, tmp_path):
         if p.is_file()
     }
     assert before == after
+
+
+def test_audit_calls_procs_with_arguments(store):
+    # with_args covers the bulk of the library that zero-arg calls miss
+    store.save_many(
+        "procs",
+        {
+            "adds": "{a b} {expr {$a + $b}}",          # wants numbers
+            "greets": "{who} {return \"hi $who\"}",     # any string works
+            "broken_with_args": "{x} {exec ls $x}",     # genuinely broken
+        },
+    )
+    report = audit_state(store, call_with_args=True)
+    procs = by_name(report)
+
+    assert procs["greets"].ran and procs["greets"].run_ok
+    assert procs["greets"].arity == 1
+
+    # "test" is not a number: that's the audit's argument being wrong, not
+    # the proc being broken
+    assert procs["adds"].ran and procs["adds"].arg_mismatch
+    assert procs["adds"].run_ok is None
+
+    assert procs["broken_with_args"].run_ok is False
+
+
+def test_audit_without_call_with_args_skips_them(store):
+    store.save_many("procs", {"greets": '{who} {return "hi $who"}'})
+    procs = by_name(audit_state(store))
+    assert not procs["greets"].ran
+    assert procs["greets"].arity == 1

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -136,3 +136,19 @@ def test_audit_without_call_with_args_skips_them(store):
     procs = by_name(audit_state(store))
     assert not procs["greets"].ran
     assert procs["greets"].arity == 1
+
+
+def test_timeouts_are_classified_separately(tmp_path):
+    from smeggdrop.state import FileStateStore
+
+    slow = FileStateStore(tmp_path)
+    slow.save_many("procs", {"spins": "{} {while 1 {}}"})
+
+    report = audit_state(slow, time_limit=1)
+    spins = by_name(report)["spins"]
+    assert spins.timed_out
+    # too slow is not the same as broken: the bot allows longer than the
+    # audit does, and some of these procs are merely heavy
+    assert spins.run_ok is None
+    assert report.summary()["timed_out"] == 1
+    assert report.summary()["run_failures"] == 0

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -21,6 +21,7 @@ def store(tmp_path):
             # bootstrap aliases `cache` globally after state load, hiding this
             "cache": "{} {return stale}",
             "fetches": "{} {http get http://example.com/}",
+            "reads_log": "{} {llength [log]}",
         },
     )
     s.save_many("vars", {"ok_var": "scalar {1}", "bad_var": "bogus {1}"})
@@ -58,6 +59,9 @@ def test_audit_full_report(store):
     assert procs["cache"].shadowed
     assert not procs["cache"].ran
 
+    # procs that read [log] get a plausible line, not an unset variable
+    assert procs["reads_log"].ran and procs["reads_log"].run_ok
+
     # reached the (stubbed) network: working proc, not a failure
     assert procs["fetches"].needs_network
     assert procs["fetches"].run_ok is None
@@ -70,7 +74,7 @@ def test_audit_full_report(store):
 def test_audit_summary_counts(store):
     report = audit_state(store)
     summary = report.summary()
-    assert summary["total"] == 8
+    assert summary["total"] == 9
     assert summary["load_failures"] == 1
     assert summary["shadowed"] == 1
     assert summary["needs_network"] == 1

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -138,23 +138,88 @@ def test_oversized_value_not_persisted(store):
     assert FileStateStore(store.root).load("vars") == {}
 
 
+class CountingFetcher:
+    def __init__(self):
+        self.calls = []
+
+    def fetch(self, url, method="GET", body=None):
+        self.calls.append((method, url, body))
+        return 200, {"Content-Type": "text/plain"}, f"ok:{url}"
+
+
 def test_curl_call_cap(store):
-    class CountingFetcher:
-        calls = 0
-
-        def fetch(self, url):
-            CountingFetcher.calls += 1
-            return 200, "ok"
-
+    fetcher = CountingFetcher()
     engine = Engine(store, limits=Limits(eval_time_seconds=2, curl_max_calls=2),
-                    fetcher=CountingFetcher())
+                    fetcher=fetcher)
     try:
         result = run(engine, "for {set i 0} {$i < 5} {incr i} {core::curl http://example.com/}")
         assert not result.ok
         assert "limit" in result.output
-        assert CountingFetcher.calls == 2
+        assert len(fetcher.calls) == 2
     finally:
         engine.close()
+
+
+def test_http_compat_from_sandbox(store):
+    fetcher = CountingFetcher()
+    engine = Engine(store, limits=Limits(eval_time_seconds=2), fetcher=fetcher)
+    try:
+        # [http get $url] -> [code {headers} body], like the tclcurl-era http.tcl
+        assert run(engine, "lindex [http get http://example.com/] 0").output == "200"
+        assert run(engine, "lindex [http get http://example.com/] 2").output == "ok:http://example.com/"
+        # meta_proc prefix matching: "http g" resolves to get
+        assert run(engine, "lindex [http g http://example.com/] 0").output == "200"
+
+        result = run(engine, "http post http://example.com/submit q {a b} lang tcl")
+        assert result.ok
+        method, url, body = fetcher.calls[-1]
+        assert method == "POST"
+        assert body == "q=a+b&lang=tcl"
+
+        headers = run(engine, "http head http://example.com/").output
+        assert "Content-Type" in headers
+    finally:
+        engine.close()
+
+
+def test_urlencode_builtin(engine):
+    assert run(engine, "core::urlencode {a b&c}").output == "a+b%26c"
+
+
+def test_tcl_automatic_error_vars_not_persisted(store, engine):
+    result = run(engine, "catch {nonexistent-cmd}; set x done")
+    assert result.ok
+    engine.close()
+    saved = FileStateStore(store.root).load("vars")
+    assert "x" in saved
+    assert "errorInfo" not in saved
+    assert "errorCode" not in saved
+
+
+def test_interp_eval_shim(engine):
+    # cache::fetch runs its miss-script through interp_eval
+    assert run(engine, "cache fetch b k {expr {2 + 3}}").output == "5"
+    assert run(engine, "cache get b k").output == "5"
+
+
+def test_loglines_reach_sandbox(engine):
+    lines = ((1700000000, "alice", "alice@host", "hello there"),
+             (1700000001, "bob", "bob@host", "hi alice"))
+    result = engine.eval(EvalRequest(code="llength [log]", loglines=lines))
+    assert result.output == "2"
+    result = engine.eval(EvalRequest(code="lindex [log] 1 3", loglines=lines))
+    assert result.output == "hi alice"
+
+
+def test_names_and_hostmask_shims(engine):
+    result = engine.eval(EvalRequest(code="names", nicks=("alice", "bob")))
+    assert engine.interp.splitlist(result.output) == ("alice", "bob")
+
+    lines = ((1700000000, "Alice", "alice!a@example.org", "yo"),)
+    result = engine.eval(EvalRequest(code="hostmask alice", loglines=lines))
+    assert result.output == "alice!a@example.org"
+    result = engine.eval(EvalRequest(code="hostmask stranger", loglines=()))
+    assert result.output == "stranger!unknown@unknown"
 
 
 def test_legacy_state_dir_loads(tmp_path):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -265,3 +265,60 @@ def test_apply_reports_real_errors(engine):
 def test_builtin_apply_stays_reachable(engine):
     # bootstrap stashes it before commands.tcl can shadow it
     assert run(engine, "tcl_apply {{x} {return $x}} ok").output == "ok"
+
+
+def test_reload_picks_up_externally_written_state(store, engine):
+    # simulate a one-off `smeggdrop repl` fix landing on disk while the
+    # engine is already running, the exact scenario hot reload is for
+    other = Engine(store, limits=Limits(eval_time_seconds=2))
+    try:
+        run(other, "proc surprise {} {return from_outside}")
+    finally:
+        other.close()
+
+    assert not run(engine, "surprise").ok  # not visible yet
+    errors = engine.reload()
+    assert errors == {}
+    assert run(engine, "surprise").output == "from_outside"
+
+
+def test_reload_preserves_engine_usability(engine):
+    engine.reload()
+    assert run(engine, "expr {6 * 7}").output == "42"
+
+
+def test_reload_reports_load_errors(store):
+    # write something that will fail to install, then confirm reload
+    # surfaces it the same way startup does
+    engine = Engine(store, limits=Limits(eval_time_seconds=2))
+    try:
+        store.save_many("procs", {"broken": "{} {unbalanced {"})
+        errors = engine.reload()
+        assert any("broken" in k for k in errors)
+        assert engine.load_errors == errors
+    finally:
+        engine.close()
+
+
+def test_reload_does_not_affect_concurrent_eval_ordering(store):
+    # a slow eval and a reload issued back-to-back must not interleave —
+    # reload only ever sees the interpreter in a consistent pre- or
+    # post-eval state, never mid-eval
+    engine = Engine(store, limits=Limits(eval_time_seconds=2))
+    try:
+        import threading
+
+        results = []
+
+        def slow_eval():
+            results.append(("eval", run(engine, "after 200; expr {1 + 1}").output))
+
+        t = threading.Thread(target=slow_eval)
+        t.start()
+        errors = engine.reload()
+        t.join()
+
+        assert errors == {}
+        assert results == [("eval", "2")]
+    finally:
+        engine.close()

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -238,3 +238,30 @@ def test_legacy_state_dir_loads(tmp_path):
         assert run(engine, "greet world").output == "hello world"
     finally:
         engine.close()
+
+
+def test_apply_supports_both_conventions(engine):
+    # Tcl 8.5+ builtin: a lambda
+    assert run(engine, "apply {{x} {expr {$x * 2}}} 21").output == "42"
+    assert run(engine, "apply {{a b} {expr {$a + $b}}} 1 2").output == "3"
+
+    # smeggdrop's older convention: a command plus an argument list, which
+    # concat flattens
+    assert run(engine, "apply {format %s-%s} {a b}").output == "a-b"
+    assert run(engine, "apply {string toupper} {hi}").output == "HI"
+
+    # the saved state contains procs using each, so both must work in one
+    # interpreter
+    assert run(engine, "proc double x {expr {$x * 2}}").ok
+    assert run(engine, "apply {double} {5}").output == "10"
+
+
+def test_apply_reports_real_errors(engine):
+    result = run(engine, "apply {{x} {this-does-not-exist}} 1")
+    assert not result.ok
+    assert "this-does-not-exist" in result.output
+
+
+def test_builtin_apply_stays_reachable(engine):
+    # bootstrap stashes it before commands.tcl can shadow it
+    assert run(engine, "tcl_apply {{x} {return $x}} ok").output == "ok"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -221,6 +221,13 @@ def test_names_and_hostmask_shims(engine):
     result = engine.eval(EvalRequest(code="hostmask stranger", loglines=()))
     assert result.output == "stranger!unknown@unknown"
 
+    # regression found live: legacy procs (remote_command_state) call this
+    # bare, expecting the caller's own hostmask -- "no target" must mean
+    # self, same convention as name
+    lines = ((1700000000, "bob", "bob!b@example.org", "hi"),)
+    result = engine.eval(EvalRequest(code="hostmask", nick="bob", loglines=lines))
+    assert result.output == "bob!b@example.org"
+
 
 def test_legacy_state_dir_loads(tmp_path):
     import hashlib

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -1,0 +1,47 @@
+import subprocess
+import sys
+
+import pytest
+
+from smeggdrop.hardening import apply_memory_limit
+
+
+def test_reads_env(monkeypatch):
+    monkeypatch.setenv("SMEGGDROP_MEMORY_MB", "0")
+    assert apply_memory_limit() is None  # explicitly disabled
+
+
+def test_explicit_zero_disables():
+    assert apply_memory_limit(0) is None
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="posix rlimits")
+def test_hostile_allocation_dies_instead_of_eating_the_host():
+    # one command, so neither the time nor command limit sees it coming;
+    # the rlimit is what stops it. Runs in a subprocess because the limit
+    # is process-wide and the failure is fatal.
+    script = """
+import resource, sys
+from smeggdrop.hardening import apply_memory_limit
+from smeggdrop.engine import Engine, EvalRequest, Limits
+from smeggdrop.state import FileStateStore
+import tempfile
+
+apply_memory_limit(512)
+soft, _ = resource.getrlimit(resource.RLIMIT_AS)
+assert soft == 512 * 1024 * 1024, soft
+
+engine = Engine(FileStateStore(tempfile.mkdtemp()), limits=Limits(eval_time_seconds=5))
+result = engine.eval(EvalRequest(code="string repeat x 40000000000"))
+print("SURVIVED", result.ok)
+engine.close()
+"""
+    proc = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, timeout=120
+    )
+    # either tcl reported the failed allocation as an eval error (bot lives)
+    # or the process died — both beat exhausting the machine's memory
+    if proc.returncode == 0:
+        assert "SURVIVED False" in proc.stdout, proc.stdout
+    else:
+        assert proc.returncode != 0

--- a/tests/test_interp.py
+++ b/tests/test_interp.py
@@ -39,6 +39,13 @@ def test_clock_aliased_from_master(interp):
     assert "1970" in interp.eval("clock format 0 -gmt 1")
 
 
+def test_encoding_readonly_subcommands(interp):
+    assert interp.eval("encoding convertto utf-8 abc") == "abc"
+    assert "utf-8" in interp.eval("encoding names")
+    with pytest.raises(TclError, match="not allowed"):
+        interp.eval("encoding system iso8859-1")
+
+
 def test_tuple_args_are_injection_safe(interp):
     hostile = 'a [exec ls] {b} $env(PATH) "; exit'
     interp.eval(("set", "x", hostile))

--- a/tests/test_interp.py
+++ b/tests/test_interp.py
@@ -79,6 +79,31 @@ def test_slave_cannot_lift_its_own_limit(interp):
         )
 
 
+def test_proc_defaults_survive_snapshot(interp):
+    # info args drops defaults; a proc that was callable with no arguments
+    # must stay that way across a save/load cycle
+    interp.eval("proc greet {{who world} {greeting hi}} {return \"$greeting $who\"}")
+    payload = interp.procs()["greet"]
+    assert payload.startswith("{{who world} {greeting hi}}")
+
+    other = SafeTclInterp()
+    try:
+        other.install_proc("greet", payload)
+        assert other.eval("greet") == "hi world"
+        assert other.eval("greet there") == "hi there"
+        # and it survives a second round trip unchanged
+        assert other.procs()["greet"] == payload
+    finally:
+        other.close()
+
+
+def test_arg_spec_without_defaults(interp):
+    interp.eval("proc plain {a b} {expr {$a + $b}}")
+    assert interp.procs()["plain"] == "{a b} {expr {$a + $b}}"
+    interp.eval("proc noargs {} {return 1}")
+    assert interp.procs()["noargs"] == "{} {return 1}"
+
+
 def test_snapshot_serialization_roundtrip(interp):
     interp.eval("proc double x {expr {$x * 2}}")
     interp.eval("set scalar_var {hello world}")

--- a/tests/test_platforms.py
+++ b/tests/test_platforms.py
@@ -43,3 +43,12 @@ def test_chunk_output_caps_total_chunks():
 
 def test_default_trigger_matches_perl_config():
     assert DEFAULT_TRIGGER.pattern == r"^\s*tcl\s"
+
+
+def test_trigger_is_case_insensitive():
+    # phone keyboards autocapitalize the first word of a message
+    assert extract_code("Tcl expr {1 + 1}") == "expr {1 + 1}"
+    assert extract_code("TCL expr {1 + 1}") == "expr {1 + 1}"
+    assert extract_code("  TcL set x 1") == "set x 1"
+    # still anchored: a mention of tcl mid-sentence is not a trigger
+    assert extract_code("I love Tcl actually") is None

--- a/tests/test_platforms.py
+++ b/tests/test_platforms.py
@@ -1,6 +1,19 @@
 import re
 
-from smeggdrop.platforms import DEFAULT_TRIGGER, chunk_output, extract_code
+from smeggdrop.platforms import DEFAULT_TRIGGER, ChatLog, chunk_output, extract_code
+
+
+def test_chat_log_accumulates_and_slurps():
+    log = ChatLog(max_lines=3)
+    for i in range(5):
+        log.append("#chan", f"nick{i}", None, f"msg {i}")
+    log.append("#other", "x", "x@y", "elsewhere")
+
+    lines = log.slurp("#chan")
+    assert [l[3] for l in lines] == ["msg 2", "msg 3", "msg 4"]  # bounded
+    assert all(len(l) == 4 for l in lines)
+    assert log.slurp("#chan") == ()  # drained
+    assert log.slurp("#other")[0][1] == "x"  # channels are independent
 
 
 def test_extract_code_default_trigger():

--- a/tests/test_sandbox_escape.py
+++ b/tests/test_sandbox_escape.py
@@ -1,0 +1,150 @@
+"""Adversarial tests: things a hostile chat user would actually try.
+
+The threat model is a stranger in a slack channel who can run arbitrary
+Tcl. They must not be able to read the bot's secrets, touch the host, or
+reach the operator's network.
+"""
+
+import os
+
+import pytest
+
+from smeggdrop.engine import Engine, EvalRequest, Limits
+from smeggdrop.state import FileStateStore
+
+
+@pytest.fixture
+def engine(tmp_path):
+    e = Engine(FileStateStore(tmp_path), limits=Limits(eval_time_seconds=3))
+    yield e
+    e.close()
+
+
+def run(engine, code):
+    return engine.eval(EvalRequest(code=code, nick="attacker", channel="#chan"))
+
+
+@pytest.fixture(autouse=True)
+def _secret_in_env(monkeypatch):
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-super-secret-do-not-leak")
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        "set env(SLACK_BOT_TOKEN)",
+        "global env; set env(SLACK_BOT_TOKEN)",
+        "set ::env(SLACK_BOT_TOKEN)",
+        "array get ::env",
+        "info library",
+        "exec env",
+        "exec sh -c {echo $SLACK_BOT_TOKEN}",
+    ],
+)
+def test_cannot_read_the_bot_token(engine, code):
+    # some of these error, some return empty (safe interps have no ::env at
+    # all); what matters is that the secret never comes back
+    result = run(engine, code)
+    assert "xoxb-super-secret" not in result.output
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        "open /etc/passwd",
+        "open ~/.aws/credentials",
+        "source /etc/passwd",
+        "glob /home/*",
+        "file readable /etc/shadow",
+        "cd /",
+        "pwd",
+        "exec cat /etc/passwd",
+        "load /usr/lib/libc.so.6",
+    ],
+)
+def test_cannot_touch_the_filesystem(engine, code):
+    assert not run(engine, code).ok
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        "socket 127.0.0.1 22",
+        "socket -server accept 8080",
+        "core::curl http://169.254.169.254/latest/meta-data/",
+        "core::curl http://127.0.0.1:8080/",
+        "core::curl http://192.168.1.1/",
+        "core::curl file:///etc/passwd",
+        "http get http://10.0.0.1/",
+    ],
+)
+def test_cannot_reach_the_local_network(engine, code):
+    result = run(engine, code)
+    assert not result.ok
+    assert "refusing" in result.output or "invalid command" in result.output
+
+
+def test_cannot_escape_via_a_nested_interp(engine):
+    # safe interps can create children, but they inherit safety and cannot
+    # be granted hidden commands by their creator
+    result = run(engine, "interp create evil; evil eval {exec ls}")
+    assert not result.ok
+    result = run(engine, "interp create -safe kid; interp expose kid exec")
+    assert not result.ok
+
+
+def test_cannot_lift_its_own_limits(engine):
+    for code in (
+        "interp limit {} time -seconds {}",
+        "interp limit {} command -value {}",
+    ):
+        assert not run(engine, code).ok
+
+
+def test_runaway_loops_are_stopped(engine):
+    for code in ("while 1 {}", "while 1 {set x 1}", "proc f {} {f}; f"):
+        assert not run(engine, code).ok
+        # and the bot keeps serving everyone else afterwards: a limit that
+        # stayed tripped would turn one hostile eval into a permanent
+        # denial of service for the whole channel
+        assert run(engine, "expr {1 + 1}").output == "2"
+
+
+def test_cannot_exit_or_crash_the_host_process(engine):
+    for code in ("exit", "exit 1", "exec kill -9 [pid]"):
+        assert not run(engine, code).ok
+    assert run(engine, "expr {2 + 2}").output == "4"
+
+
+def test_cannot_write_outside_the_state_directory(engine, tmp_path):
+    # names are hashed, so even a traversal-shaped proc name stays put
+    result = run(engine, "proc {../../../../tmp/pwned} {} {return 1}")
+    assert result.ok
+    assert not (tmp_path.parent.parent / "pwned").exists()
+    assert not os.path.exists("/tmp/pwned")
+
+
+def test_output_flooding_is_capped(tmp_path):
+    engine = Engine(
+        FileStateStore(tmp_path), limits=Limits(eval_time_seconds=3, result_max_chars=500)
+    )
+    try:
+        result = engine.eval(EvalRequest(code="string repeat 'spam ' 100000"))
+        assert len(result.output) < 700
+    finally:
+        engine.close()
+
+
+def test_state_cannot_be_stuffed_in_one_eval(tmp_path):
+    engine = Engine(
+        FileStateStore(tmp_path),
+        limits=Limits(eval_time_seconds=3, max_changes_per_eval=10),
+    )
+    try:
+        result = engine.eval(
+            EvalRequest(code="for {set i 0} {$i < 500} {incr i} {set junk_$i x}")
+        )
+        assert result.warnings
+    finally:
+        engine.close()
+    assert FileStateStore(tmp_path).load("vars") == {}

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -34,6 +34,20 @@ def test_validate_allows_public_literal():
 
 
 class Handler(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(length)
+        reply = b"posted:" + body
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(reply)))
+        self.end_headers()
+        self.wfile.write(reply)
+
+    def do_HEAD(self):
+        self.send_response(200)
+        self.send_header("X-Smeg", "yes")
+        self.end_headers()
+
     def do_GET(self):
         if self.path == "/hello":
             body = b"hello world"
@@ -75,17 +89,22 @@ def server():
 @pytest.fixture
 def fetcher():
     # allow_private so tests can hit the local server; production default is off
-    return SafeFetcher(FetchPolicy(allow_private=True, max_bytes=1000, max_redirects=2, timeout=5))
+    return SafeFetcher(
+        FetchPolicy(
+            allow_private=True, max_bytes=1000, max_post_bytes=1000, max_redirects=2, timeout=5
+        )
+    )
 
 
 def test_fetch_ok(server, fetcher):
-    status, body = fetcher.fetch(server + "/hello")
+    status, headers, body = fetcher.fetch(server + "/hello")
     assert status == 200
     assert body == "hello world"
+    assert headers.get("Content-Length") == str(len("hello world"))
 
 
 def test_fetch_follows_redirect(server, fetcher):
-    status, body = fetcher.fetch(server + "/redirect")
+    status, _, body = fetcher.fetch(server + "/redirect")
     assert status == 200
     assert body == "hello world"
 
@@ -96,11 +115,34 @@ def test_fetch_redirect_loop_capped(server, fetcher):
 
 
 def test_fetch_body_capped(server, fetcher):
-    status, body = fetcher.fetch(server + "/big")
+    status, _, body = fetcher.fetch(server + "/big")
     assert status == 200
     assert len(body) == 1000
 
 
 def test_fetch_non_2xx_returned_not_raised(server, fetcher):
-    status, _ = fetcher.fetch(server + "/nope")
+    status, _, _ = fetcher.fetch(server + "/nope")
     assert status == 404
+
+
+def test_fetch_post(server, fetcher):
+    status, _, body = fetcher.fetch(server + "/echo", method="POST", body="a=1&b=2")
+    assert status == 200
+    assert body == "posted:a=1&b=2"
+
+
+def test_fetch_head(server, fetcher):
+    status, headers, body = fetcher.fetch(server + "/hello", method="HEAD")
+    assert status == 200
+    assert headers.get("X-Smeg") == "yes"
+    assert body == ""
+
+
+def test_post_body_capped(server, fetcher):
+    with pytest.raises(FetchError, match="post body"):
+        fetcher.fetch(server + "/echo", method="POST", body="x" * 5000)
+
+
+def test_unsupported_method_refused(fetcher):
+    with pytest.raises(FetchError, match="method"):
+        fetcher.fetch("http://example.com/", method="DELETE")

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -146,3 +146,31 @@ def test_post_body_capped(server, fetcher):
 def test_unsupported_method_refused(fetcher):
     with pytest.raises(FetchError, match="method"):
         fetcher.fetch("http://example.com/", method="DELETE")
+
+
+def test_redirect_to_private_address_is_blocked_under_production_policy():
+    # named regression for a specific attack shape: an attacker-controlled
+    # public host redirects to a loopback/private target, hoping the
+    # redirect hop skips revalidation. It doesn't -- validate() runs again
+    # on every hop, under whatever policy the caller actually configured
+    # (production default: allow_private=False), not a relaxed test-only one.
+    from unittest.mock import patch
+
+    fetcher = SafeFetcher(FetchPolicy(timeout=3))
+
+    class FakeRedirectResponse:
+        status = 302
+        headers = {"Location": "http://127.0.0.1/secret"}
+
+        def read(self, n):
+            return b""
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    with patch.object(fetcher._opener, "open", return_value=FakeRedirectResponse()):
+        with pytest.raises(FetchError, match="non-public address"):
+            fetcher.fetch("http://example.com/")

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -396,3 +396,27 @@ def test_retry_after_header_is_honoured():
         response = Response()
 
     assert retry_after_seconds(Err()) == 7.0
+
+
+@pytest.mark.parametrize(
+    "text,code",
+    [
+        ("tcl `snoe`", "snoe"),
+        ("tcl ```expr {1 + 1}```", "expr {1 + 1}"),
+        ("`tcl snoe`", "snoe"),
+        ("tcl expr {1 + 1}", "expr {1 + 1}"),
+    ],
+)
+def test_backtick_wrapped_commands_run(engine, cfg, text, code):
+    # people copy commands out of code-formatted messages
+    from smeggdrop.platforms.slack import unwrap_backticks, unfuck_slack_message
+    from smeggdrop.platforms import extract_code
+
+    extracted = extract_code(unfuck_slack_message(text), cfg.trigger)
+    assert unwrap_backticks(extracted) == code
+
+
+def test_backticked_command_evaluates(engine, cfg):
+    client = StubClient()
+    assert handle_message_event(engine, client, event("tcl `expr {6 * 7}`"), cfg)
+    assert client.posted == [("C123", "```42```")]

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -294,3 +294,26 @@ def test_replies_ask_slack_not_to_linkify(engine, cfg):
     assert calls[0]["parse"] == "none"
     assert calls[0]["link_names"] is False
     assert calls[0]["unfurl_links"] is False
+
+
+def test_event_deduper_claims_once():
+    from smeggdrop.platforms.slack import EventDeduper
+
+    d = EventDeduper()
+    assert d.claim("Ev1") is True
+    assert d.claim("Ev1") is False
+    assert d.claim("Ev2") is True
+    # no id to dedupe on: run it rather than lose it
+    assert d.claim(None) is True
+    assert d.claim(None) is True
+
+
+def test_event_deduper_is_bounded():
+    from smeggdrop.platforms.slack import EventDeduper
+
+    d = EventDeduper(capacity=3)
+    for i in range(10):
+        assert d.claim(f"Ev{i}") is True
+    assert len(d._seen) == 3
+    assert d.claim("Ev9") is False  # recent ids still remembered
+    assert d.claim("Ev0") is True  # oldest evicted

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -1,0 +1,175 @@
+# tests for the slack adapter's decision logic; no slack sdk required —
+# the client is duck-typed and bolt is only imported inside build_app()
+
+import pytest
+
+from smeggdrop.engine import Engine, Limits
+from smeggdrop.platforms.slack import (
+    NickCache,
+    SlackConfig,
+    format_reply,
+    handle_message_event,
+    unfuck_slack_message,
+)
+from smeggdrop.state import FileStateStore
+
+
+class StubClient:
+    def __init__(self, user_names=None):
+        self.posted = []
+        self.user_names = user_names or {}
+
+    def chat_postMessage(self, *, channel, text, **kwargs):
+        self.posted.append((channel, text))
+
+    def users_info(self, *, user):
+        if user not in self.user_names:
+            raise RuntimeError("user_not_found")
+        return {"user": {"name": self.user_names[user], "profile": {}}}
+
+
+@pytest.fixture
+def engine(tmp_path):
+    e = Engine(FileStateStore(tmp_path), limits=Limits(eval_time_seconds=2))
+    yield e
+    e.close()
+
+
+@pytest.fixture
+def cfg():
+    return SlackConfig()
+
+
+def event(text, **kw):
+    return {"type": "message", "channel": "C123", "user": "U1", "text": text, **kw}
+
+
+def test_trigger_evaluates_and_replies(engine, cfg):
+    client = StubClient(user_names={"U1": "alice"})
+    assert handle_message_event(engine, client, event("tcl expr {6 * 7}"), cfg)
+    assert client.posted == [("C123", "```42```")]
+
+
+def test_non_trigger_ignored(engine, cfg):
+    client = StubClient()
+    assert not handle_message_event(engine, client, event("just chatting about tcl"), cfg)
+    assert client.posted == []
+
+
+def test_bot_messages_never_evaluated(engine, cfg):
+    client = StubClient()
+    assert not handle_message_event(
+        engine, client, event("tcl expr 1", bot_id="B999"), cfg
+    )
+    assert not handle_message_event(
+        engine, client, event("tcl expr 1", subtype="bot_message"), cfg
+    )
+    assert client.posted == []
+
+
+def test_edited_message_evaluated(engine, cfg):
+    client = StubClient()
+    evt = {
+        "type": "message",
+        "subtype": "message_changed",
+        "channel": "C123",
+        "message": {"user": "U1", "text": "tcl expr {1 + 1}"},
+    }
+    assert handle_message_event(engine, client, evt, cfg)
+    assert client.posted == [("C123", "```2```")]
+
+
+def test_channel_allowlist(engine):
+    cfg = SlackConfig(channels=frozenset({"CALLOWED"}))
+    client = StubClient()
+    assert not handle_message_event(engine, client, event("tcl expr 1"), cfg)
+    assert client.posted == []
+
+
+def test_nick_reaches_sandbox(engine, cfg):
+    client = StubClient(user_names={"U1": "alice"})
+    handle_message_event(engine, client, event("tcl nick"), cfg)
+    assert client.posted == [("C123", "```alice```")]
+
+
+def test_nick_falls_back_to_id(engine, cfg):
+    client = StubClient()  # users_info fails
+    handle_message_event(engine, client, event("tcl nick"), cfg)
+    assert client.posted == [("C123", "```U1```")]
+
+
+def test_say_posts_immediately(engine, cfg):
+    client = StubClient()
+    handle_message_event(engine, client, event("tcl core::bot_say hi there"), cfg)
+    assert client.posted[0] == ("C123", "hi there")
+
+
+def test_error_reply(engine, cfg):
+    client = StubClient()
+    handle_message_event(engine, client, event("tcl no-such-command"), cfg)
+    assert len(client.posted) == 1
+    assert client.posted[0][1].startswith("```error:")
+
+
+def test_slack_mangled_url_unwrapped(engine, cfg):
+    client = StubClient()
+    handle_message_event(
+        engine, client, event("tcl string length <http://x.io/a?b=1|x.io/a?b=1>"), cfg
+    )
+    assert client.posted == [("C123", "```%d```" % len("http://x.io/a?b=1"))]
+
+
+@pytest.mark.parametrize(
+    "mangled,clean",
+    [
+        ("<http://example.com|example.com>", "http://example.com"),
+        ("<https://example.com/x>", "https://example.com/x"),
+        ("`tcl expr 1`", "tcl expr 1"),
+        ("a &amp; b &lt;c&gt;", "a & b <c>"),
+        ("plain text", "plain text"),
+    ],
+)
+def test_unfuck_slack_message(mangled, clean):
+    assert unfuck_slack_message(mangled) == clean
+
+
+def test_format_reply_fences_and_truncates():
+    messages = format_reply(True, "x" * 20000, [])
+    assert all(m.startswith("```") and m.endswith("```") for m in messages)
+    assert len(messages) <= 3
+    assert "(truncated)" in messages[-1]
+
+
+def test_format_reply_escapes_fences_and_warnings():
+    (message,) = format_reply(True, "a```b", ["heads up"])
+    assert "'''" in message
+    assert "warning: heads up" in message
+
+
+def test_format_reply_empty_output():
+    assert format_reply(True, "", []) == ["```(no output)```"]
+
+
+def test_config_from_env():
+    cfg = SlackConfig.from_env(
+        {
+            "SMEGGDROP_TRIGGER": r"^!eval\s",
+            "SMEGGDROP_CHANNELS": "C1, C2 ,",
+            "SMEGGDROP_STATE": "/data/state",
+            "SMEGGDROP_TIME_LIMIT": "3",
+            "SLACK_APP_TOKEN": "xapp-1",
+        }
+    )
+    assert cfg.trigger.pattern == r"^!eval\s"
+    assert cfg.channels == frozenset({"C1", "C2"})
+    assert cfg.state_dir == "/data/state"
+    assert cfg.time_limit == 3
+    assert cfg.app_token == "xapp-1"
+
+
+def test_nick_cache_caches(engine):
+    client = StubClient(user_names={"U1": "alice"})
+    cache = NickCache()
+    assert cache.resolve(client, "U1") == "alice"
+    client.user_names.clear()
+    assert cache.resolve(client, "U1") == "alice"

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -9,15 +9,17 @@ from smeggdrop.platforms.slack import (
     SlackConfig,
     format_reply,
     handle_message_event,
+    strip_irc_formatting,
     unfuck_slack_message,
 )
 from smeggdrop.state import FileStateStore
 
 
 class StubClient:
-    def __init__(self, user_names=None):
+    def __init__(self, user_names=None, channel_names=None):
         self.posted = []
         self.user_names = user_names or {}
+        self.channel_names = channel_names if channel_names is not None else {"C123": "tcl"}
 
     def chat_postMessage(self, *, channel, text, **kwargs):
         self.posted.append((channel, text))
@@ -26,6 +28,11 @@ class StubClient:
         if user not in self.user_names:
             raise RuntimeError("user_not_found")
         return {"user": {"name": self.user_names[user], "profile": {}}}
+
+    def conversations_info(self, *, channel):
+        if channel not in self.channel_names:
+            raise RuntimeError("channel_not_found")
+        return {"channel": {"name": self.channel_names[channel]}}
 
 
 @pytest.fixture
@@ -182,6 +189,48 @@ def test_chat_log_feeds_eval_and_drains(engine, cfg):
     client.posted.clear()
     handle_message_event(engine, client, event("tcl llength [log]"), cfg, chat_log=chat_log)
     assert client.posted == [("C123", "```0```")]  # slurped by the previous eval
+
+
+def test_channel_reaches_sandbox_as_irc_name(engine, cfg):
+    # saved procs print [channel] and key cache buckets off it, so it has
+    # to look like an irc channel, not a slack id
+    client = StubClient()
+    handle_message_event(engine, client, event("tcl channel"), cfg)
+    assert client.posted == [("C123", "```#tcl```")]
+
+
+def test_channel_falls_back_to_id(engine, cfg):
+    client = StubClient(channel_names={})
+    handle_message_event(engine, client, event("tcl channel"), cfg)
+    assert client.posted == [("C123", "```C123```")]
+
+
+@pytest.mark.parametrize(
+    "raw,clean",
+    [
+        ("\x0304,04***\x03 hi", "*** hi"),
+        ("\x02bold\x0f", "bold"),
+        ("\x034red\x03", "red"),
+        ("\x1funderline\x16", "underline"),
+        ("no formatting", "no formatting"),
+    ],
+)
+def test_strip_irc_formatting(raw, clean):
+    assert strip_irc_formatting(raw) == clean
+
+
+def test_reply_strips_irc_colors(engine, cfg):
+    # ascii art from the state is full of mIRC colour codes; slack renders
+    # none of them, leaving literal "04,04" garbage if not stripped
+    client = StubClient()
+    handle_message_event(engine, client, event("tcl set x {\x0304,04* art}"), cfg)
+    assert client.posted == [("C123", "```* art```")]
+
+
+def test_say_strips_irc_colors(engine, cfg):
+    client = StubClient()
+    handle_message_event(engine, client, event("tcl core::bot_say \x0304,04*\x03 said"), cfg)
+    assert client.posted[0] == ("C123", "* said")
 
 
 def test_nick_cache_caches(engine):

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -167,6 +167,23 @@ def test_config_from_env():
     assert cfg.app_token == "xapp-1"
 
 
+def test_chat_log_feeds_eval_and_drains(engine, cfg):
+    from smeggdrop.platforms import ChatLog
+
+    client = StubClient(user_names={"U1": "alice", "U2": "bob"})
+    chat_log = ChatLog()
+
+    assert not handle_message_event(
+        engine, client, {**event("what a day"), "user": "U2"}, cfg, chat_log=chat_log
+    )
+    handle_message_event(engine, client, event("tcl lindex [log] 0 3"), cfg, chat_log=chat_log)
+    assert client.posted == [("C123", "```what a day```")]
+
+    client.posted.clear()
+    handle_message_event(engine, client, event("tcl llength [log]"), cfg, chat_log=chat_log)
+    assert client.posted == [("C123", "```0```")]  # slurped by the previous eval
+
+
 def test_nick_cache_caches(engine):
     client = StubClient(user_names={"U1": "alice"})
     cache = NickCache()

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -328,3 +328,71 @@ def test_capitalized_trigger_works_end_to_end(engine, cfg):
 def test_env_trigger_is_also_case_insensitive():
     cfg = SlackConfig.from_env({"SMEGGDROP_TRIGGER": r"^!eval\s"})
     assert cfg.trigger.search("!EVAL puts hi")
+
+
+class FlakyClient(StubClient):
+    """Fails the first `failures` posts with a transient error."""
+
+    def __init__(self, failures=1, error=None, **kw):
+        super().__init__(**kw)
+        self.failures = failures
+        self.attempts = 0
+        self.error = error or OSError("_ssl.c:983: The handshake operation timed out")
+
+    def chat_postMessage(self, **kwargs):
+        self.attempts += 1
+        if self.attempts <= self.failures:
+            raise self.error
+        return super().chat_postMessage(channel=kwargs["channel"], text=kwargs["text"])
+
+
+def test_transient_post_failure_is_retried(engine, cfg, monkeypatch):
+    monkeypatch.setattr("smeggdrop.platforms.slack.POST_BACKOFF_SECONDS", 0)
+    client = FlakyClient(failures=2)
+    handle_message_event(engine, client, event("tcl expr {6 * 7}"), cfg)
+    assert client.attempts == 3
+    assert client.posted == [("C123", "```42```")]
+
+
+def test_permanent_post_failure_is_not_retried(engine, cfg):
+    client = FlakyClient(failures=5, error=RuntimeError("channel_not_found"))
+    with pytest.raises(RuntimeError):
+        handle_message_event(engine, client, event("tcl expr {6 * 7}"), cfg)
+    assert client.attempts == 1
+
+
+def test_retry_gives_up_and_raises(engine, cfg, monkeypatch):
+    monkeypatch.setattr("smeggdrop.platforms.slack.POST_BACKOFF_SECONDS", 0)
+    client = FlakyClient(failures=99)
+    with pytest.raises(OSError):
+        handle_message_event(engine, client, event("tcl expr {6 * 7}"), cfg)
+    assert client.attempts == 3
+
+
+@pytest.mark.parametrize(
+    "error,transient",
+    [
+        (OSError("handshake operation timed out"), True),
+        (OSError("Connection reset by peer"), True),
+        (RuntimeError("ratelimited"), True),
+        (RuntimeError("channel_not_found"), False),
+        (RuntimeError("invalid_auth"), False),
+    ],
+)
+def test_is_transient(error, transient):
+    from smeggdrop.platforms.slack import is_transient
+
+    assert is_transient(error) is transient
+
+
+def test_retry_after_header_is_honoured():
+    from smeggdrop.platforms.slack import retry_after_seconds
+
+    class Response:
+        status_code = 429
+        headers = {"Retry-After": ["7"]}
+
+    class Err(Exception):
+        response = Response()
+
+    assert retry_after_seconds(Err()) == 7.0

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -134,6 +134,12 @@ def test_slack_mangled_url_unwrapped(engine, cfg):
         ("`tcl expr 1`", "tcl expr 1"),
         ("a &amp; b &lt;c&gt;", "a & b <c>"),
         ("plain text", "plain text"),
+        # regression: slack sometimes delivers link markup with the angle
+        # brackets html-escaped (&lt;url|label&gt; instead of <url|label>) --
+        # observed live from a real user pasting <http://x|x>. Unescaping
+        # has to happen before the url-unwrap regex or it never fires.
+        ("&lt;http://example.com|example.com&gt;", "http://example.com"),
+        ("&lt;https://example.com/x&gt;", "https://example.com/x"),
     ],
 )
 def test_unfuck_slack_message(mangled, clean):
@@ -420,3 +426,18 @@ def test_backticked_command_evaluates(engine, cfg):
     client = StubClient()
     assert handle_message_event(engine, client, event("tcl `expr {6 * 7}`"), cfg)
     assert client.posted == [("C123", "```42```")]
+
+
+def test_html_escaped_link_markup_reaches_the_fetcher(engine, cfg):
+    # regression: this exact shape (html-escaped <url|label>) was observed
+    # live and used to fail with "refusing scheme ''" -- a malformed-url
+    # artifact of the ordering bug, not a real SSRF block. After the fix it
+    # should unwrap to a clean http:// URL and fail for the real reason
+    # (unresolvable host), proving the fetcher is actually being reached.
+    client = StubClient()
+    handle_message_event(
+        engine, client, event("tcl core::curl &lt;http://nonexistent.invalid|x&gt;"), cfg
+    )
+    assert len(client.posted) == 1
+    assert "cannot resolve" in client.posted[0][1]
+    assert "refusing scheme ''" not in client.posted[0][1]

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -441,3 +441,35 @@ def test_html_escaped_link_markup_reaches_the_fetcher(engine, cfg):
     assert len(client.posted) == 1
     assert "cannot resolve" in client.posted[0][1]
     assert "refusing scheme ''" not in client.posted[0][1]
+
+
+def test_blocked_user_is_silently_ignored(engine):
+    cfg = SlackConfig(blocked_users=frozenset({"U1"}))
+    client = StubClient(user_names={"U1": "attacker"})
+    assert not handle_message_event(engine, client, event("tcl expr {1 + 1}"), cfg)
+    assert client.posted == []
+
+
+def test_blocked_user_keyed_on_id_not_display_name(engine):
+    # blocking must survive a nick/display-name change -- it's the same
+    # slack account, U1, regardless of what name it currently shows
+    cfg = SlackConfig(blocked_users=frozenset({"U1"}))
+    client = StubClient(user_names={"U1": "totally-different-name-now"})
+    assert not handle_message_event(engine, client, event("tcl expr {1 + 1}"), cfg)
+    assert client.posted == []
+
+
+def test_other_users_unaffected_by_block(engine, cfg):
+    blocking_cfg = SlackConfig(blocked_users=frozenset({"U999"}))
+    client = StubClient(user_names={"U1": "alice"})
+    assert handle_message_event(engine, client, event("tcl expr {1 + 1}"), blocking_cfg)
+    assert client.posted == [("C123", "```2```")]
+
+
+def test_blocked_users_config_from_env():
+    cfg = SlackConfig.from_env({"SMEGGDROP_BLOCKED_USERS": "U1, U2 ,"})
+    assert cfg.blocked_users == frozenset({"U1", "U2"})
+
+
+def test_no_blocked_users_by_default():
+    assert SlackConfig().blocked_users == frozenset()

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -317,3 +317,14 @@ def test_event_deduper_is_bounded():
     assert len(d._seen) == 3
     assert d.claim("Ev9") is False  # recent ids still remembered
     assert d.claim("Ev0") is True  # oldest evicted
+
+
+def test_capitalized_trigger_works_end_to_end(engine, cfg):
+    client = StubClient()
+    assert handle_message_event(engine, client, event("Tcl expr {6 * 7}"), cfg)
+    assert client.posted == [("C123", "```42```")]
+
+
+def test_env_trigger_is_also_case_insensitive():
+    cfg = SlackConfig.from_env({"SMEGGDROP_TRIGGER": r"^!eval\s"})
+    assert cfg.trigger.search("!EVAL puts hi")

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -239,3 +239,58 @@ def test_nick_cache_caches(engine):
     assert cache.resolve(client, "U1") == "alice"
     client.user_names.clear()
     assert cache.resolve(client, "U1") == "alice"
+
+
+def test_user_mentions_become_nicks(engine, cfg):
+    # procs were written for irc: `deathto winkie` must see the nick, not
+    # the raw <@U123> slack sends
+    client = StubClient(user_names={"U1": "alice", "U99": "winkie"})
+    handle_message_event(engine, client, event("tcl set x <@U99>"), cfg)
+    assert client.posted == [("C123", "```winkie```")]
+
+
+def test_mention_with_label_uses_the_label(engine, cfg):
+    client = StubClient()
+    handle_message_event(engine, client, event("tcl set x <@U99|winkie>"), cfg)
+    assert client.posted == [("C123", "```winkie```")]
+
+
+@pytest.mark.parametrize(
+    "raw,resolved",
+    [
+        ("<#C5|general>", "#general"),
+        ("<!here>", "here"),
+        ("<!channel>", "channel"),
+        ("<!subteam^S1|@team>", "@team"),
+    ],
+)
+def test_other_mention_forms_resolved(engine, cfg, raw, resolved):
+    client = StubClient()
+    handle_message_event(engine, client, event(f"tcl set x {{{raw}}}"), cfg)
+    assert client.posted == [("C123", f"```{resolved}```")]
+
+
+@pytest.mark.parametrize(
+    "hostile",
+    ["<!channel>", "<!here>", "<!everyone>", "<@U404>", "<#C404|general>"],
+)
+def test_bot_cannot_be_used_as_a_ping_cannon(hostile):
+    # a hostile eval (or a saved proc holding mention markup) must not be
+    # able to notify a whole workspace on demand
+    messages = format_reply(True, f"wake up {hostile}", [])
+    assert len(messages) == 1
+    assert hostile not in messages[0]
+
+
+def test_replies_ask_slack_not_to_linkify(engine, cfg):
+    calls = []
+
+    class RecordingClient(StubClient):
+        def chat_postMessage(self, **kwargs):
+            calls.append(kwargs)
+            return super().chat_postMessage(channel=kwargs["channel"], text=kwargs["text"])
+
+    handle_message_event(engine, RecordingClient(), event("tcl expr {1 + 1}"), cfg)
+    assert calls[0]["parse"] == "none"
+    assert calls[0]["link_names"] is False
+    assert calls[0]["unfurl_links"] is False

--- a/tests/test_slack_wiring.py
+++ b/tests/test_slack_wiring.py
@@ -67,14 +67,14 @@ def fake_authorize(**kwargs):
     )
 
 
-def event_request(text, channel="C123", retry_num="0"):
+def event_request(text, channel="C123", retry_num="0", event_id="Ev1"):
     from slack_bolt.request import BoltRequest
 
     body = {
         "team_id": "T1",
         "api_app_id": "A1",
         "type": "event_callback",
-        "event_id": "Ev1",
+        "event_id": event_id,
         "event_time": 1,
         "event": {
             "type": "message",
@@ -141,11 +141,22 @@ def test_missing_retry_header_is_fine(engine, posted):
     assert wait_for(posted, 1) == [("C123", "```2```")]
 
 
-def test_actual_retries_are_dropped(engine, posted):
+def test_duplicate_delivery_runs_once(engine, posted):
     app = make_app(engine)
-    app.dispatch(event_request("tcl expr {1 + 1}", retry_num="2"))
+    app.dispatch(event_request("tcl expr {1 + 1}", event_id="EvDup"))
+    assert wait_for(posted, 1) == [("C123", "```2```")]
+    # slack redelivering the same event must not re-run it
+    app.dispatch(event_request("tcl expr {1 + 1}", retry_num="1", event_id="EvDup"))
     settle()
-    assert posted == []
+    assert len(posted) == 1
+
+
+def test_retry_of_an_unseen_event_still_runs(engine, posted):
+    # the case that was silently losing messages: the first delivery went
+    # unacked (bot restarting), so the retry is the only chance to run it
+    app = make_app(engine)
+    app.dispatch(event_request("tcl expr {1 + 1}", retry_num="1", event_id="EvMissed"))
+    assert wait_for(posted, 1) == [("C123", "```2```")]
 
 
 def test_non_triggers_are_ignored(engine, posted):

--- a/tests/test_slack_wiring.py
+++ b/tests/test_slack_wiring.py
@@ -1,0 +1,173 @@
+"""Does the bolt app actually invoke the handler, for real requests?
+
+A total failure to respond got past the rest of the suite and only turned
+up against a live workspace: every other test calls handle_message_event
+directly, so nothing covered the middleware or the listener registration.
+
+The bug was the retry-dropping middleware testing for the *presence* of
+x-slack-retry-num. Slack sets that header on first delivery too, valued 0,
+so every message was silently discarded — acked in 0ms with nothing logged.
+
+(A lazy-listener theory was investigated and disproved along the way:
+`test_lazy_wiring_also_runs` pins the actual behaviour, which is that bolt
+runs lazy listeners outside FaaS too, via its thread pool.)
+
+These drive real BoltRequests through app.dispatch().
+"""
+
+import json
+import time
+
+import pytest
+
+from smeggdrop.engine import Engine, Limits
+from smeggdrop.platforms.slack import SlackConfig, build_app
+from smeggdrop.state import FileStateStore
+
+pytest.importorskip("slack_bolt")
+
+from slack_sdk.web import WebClient  # noqa: E402  (must follow importorskip)
+
+
+@pytest.fixture
+def posted(monkeypatch):
+    """Capture outbound api calls at the class level.
+
+    Bolt constructs its own WebClient per request from the authorize
+    result, so patching an instance handed to build_app would be ignored.
+    """
+    sent: list[tuple[str, str]] = []
+
+    def chat_postMessage(self, *, channel, text=None, **kwargs):
+        sent.append((channel, text))
+        return {"ok": True, "ts": "1.0"}
+
+    def users_info(self, *, user, **kwargs):
+        return {"user": {"name": "alice", "profile": {}}}
+
+    def conversations_info(self, *, channel, **kwargs):
+        return {"channel": {"name": "tcl"}}
+
+    monkeypatch.setattr(WebClient, "chat_postMessage", chat_postMessage)
+    monkeypatch.setattr(WebClient, "users_info", users_info)
+    monkeypatch.setattr(WebClient, "conversations_info", conversations_info)
+    return sent
+
+
+def fake_authorize(**kwargs):
+    """Avoid bolt's auth.test round trip to slack."""
+    from slack_bolt.authorization import AuthorizeResult
+
+    return AuthorizeResult(
+        enterprise_id=None,
+        team_id="T1",
+        bot_token="xoxb-test",
+        bot_id="BBOT",
+        bot_user_id="UBOT",
+    )
+
+
+def event_request(text, channel="C123", retry_num="0"):
+    from slack_bolt.request import BoltRequest
+
+    body = {
+        "team_id": "T1",
+        "api_app_id": "A1",
+        "type": "event_callback",
+        "event_id": "Ev1",
+        "event_time": 1,
+        "event": {
+            "type": "message",
+            "channel": channel,
+            "user": "U1",
+            "text": text,
+            "ts": "1.0",
+        },
+    }
+    headers = {"content-type": ["application/json"]}
+    if retry_num is not None:
+        headers["x-slack-retry-num"] = [retry_num]
+    return BoltRequest(body=json.dumps(body), headers=headers, mode="socket_mode")
+
+
+def wait_for(sent, count, timeout=15.0):
+    """Non-lazy listeners run in bolt's thread pool, so dispatch returns
+    before the eval finishes."""
+    deadline = time.time() + timeout
+    while time.time() < deadline and len(sent) < count:
+        time.sleep(0.05)
+    return sent
+
+
+def settle(seconds=1.5):
+    """Give a listener thread time to run when expecting no output."""
+    time.sleep(seconds)
+
+
+def make_app(engine, **kwargs):
+    return build_app(
+        engine,
+        SlackConfig(channels=frozenset({"C123"})),
+        signing_secret="secret",
+        request_verification_enabled=False,
+        authorize=fake_authorize,
+        **kwargs,
+    )
+
+
+@pytest.fixture
+def engine(tmp_path):
+    e = Engine(FileStateStore(tmp_path), limits=Limits(eval_time_seconds=3))
+    yield e
+    e.close()
+
+
+def test_socket_mode_wiring_runs_the_eval(engine, posted):
+    app = make_app(engine)
+    response = app.dispatch(event_request("tcl expr {40 + 2}"))
+    assert response.status == 200
+    assert wait_for(posted, 1) == [("C123", "```42```")]
+
+
+def test_first_delivery_is_not_treated_as_a_retry(engine, posted):
+    app = make_app(engine)
+    app.dispatch(event_request("tcl expr {1 + 1}", retry_num="0"))
+    assert wait_for(posted, 1) == [("C123", "```2```")]
+
+
+def test_missing_retry_header_is_fine(engine, posted):
+    app = make_app(engine)
+    app.dispatch(event_request("tcl expr {1 + 1}", retry_num=None))
+    assert wait_for(posted, 1) == [("C123", "```2```")]
+
+
+def test_actual_retries_are_dropped(engine, posted):
+    app = make_app(engine)
+    app.dispatch(event_request("tcl expr {1 + 1}", retry_num="2"))
+    settle()
+    assert posted == []
+
+
+def test_non_triggers_are_ignored(engine, posted):
+    app = make_app(engine)
+    app.dispatch(event_request("just chatting about tcl"))
+    settle()
+    assert posted == []
+
+
+def test_other_channels_are_ignored(engine, posted):
+    app = make_app(engine)
+    app.dispatch(event_request("tcl expr {1 + 1}", channel="COTHER"))
+    settle()
+    assert posted == []
+
+
+def test_lazy_wiring_also_runs(engine, posted):
+    # The FaaS shape acks first and defers the eval. Outside a FaaS adapter
+    # bolt still runs lazy listeners, in its thread pool, rather than
+    # dropping them — so this must not be asserted as "posts nothing".
+    # Pinning it because the opposite was assumed while debugging.
+    app = make_app(engine, lazy=True)
+    response = app.dispatch(event_request("tcl expr {40 + 2}"))
+    assert response.status == 200
+    assert wait_for(posted, 1) == [("C123", "```42```")]

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -79,3 +79,18 @@ def test_names_never_become_paths(tmp_path):
     assert (tmp_path / "procs" / name_sha1(evil)).exists()
     assert not (tmp_path.parent / "escape").exists()
     assert FileStateStore(tmp_path).load("procs") == {evil: "{} {return x}"}
+
+
+def test_open_store_dispatches_on_location(tmp_path, monkeypatch):
+    from smeggdrop.state import FileStateStore as FSS
+    from smeggdrop.state import open_store
+
+    assert isinstance(open_store(str(tmp_path)), FSS)
+
+    # s3 uris get the s3 store, without needing credentials to construct
+    import smeggdrop.state_s3 as state_s3
+
+    monkeypatch.setattr(state_s3.S3StateStore, "client", property(lambda self: None))
+    store = open_store("s3://bucket/prefix")
+    assert isinstance(store, state_s3.S3StateStore)
+    assert store.bucket == "bucket"

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -94,3 +94,25 @@ def test_open_store_dispatches_on_location(tmp_path, monkeypatch):
     store = open_store("s3://bucket/prefix")
     assert isinstance(store, state_s3.S3StateStore)
     assert store.bucket == "bucket"
+
+
+def test_legacy_latin1_bytes_survive_loading(tmp_path):
+    # the perl bot used `use bytes`, so some procs hold latin-1 art:
+    # ¯`·.¸¸.·´¯ waves and °_o faces. errors="replace" destroyed them.
+    from smeggdrop.state import decode
+
+    procs = tmp_path / "procs"
+    procs.mkdir(parents=True)
+    (tmp_path / "vars").mkdir()
+    raw = b'{} { return "\xb0_o \xb7_. \xaf`\xb7.\xb8\xb8.\xb7\xb4\xaf" }'
+    sha = name_sha1("face")
+    (procs / "_index").write_text("{face} %s\n" % sha)
+    (procs / sha).write_bytes(raw)
+
+    loaded = FileStateStore(tmp_path).load("procs")["face"]
+    assert "�" not in loaded
+    assert "°_o" in loaded and "·_." in loaded
+    assert "¯`·.¸¸.·´¯" in loaded
+
+    # utf-8 content still decodes as utf-8, not mojibake
+    assert decode("✗ ünïcode".encode("utf-8")) == "✗ ünïcode"

--- a/tests/test_state_s3.py
+++ b/tests/test_state_s3.py
@@ -1,0 +1,146 @@
+"""S3 state store, exercised against a fake S3 that mimics the parts we use:
+ETags, conditional writes, and NoSuchKey."""
+
+import json
+
+import pytest
+
+from smeggdrop.state_s3 import S3StateStore
+
+
+class FakeS3:
+    """Minimal S3: objects with ETags and If-Match/If-None-Match semantics."""
+
+    def __init__(self):
+        self.objects: dict[tuple[str, str], bytes] = {}
+        self.etags: dict[tuple[str, str], str] = {}
+        self.puts = 0
+        self._counter = 0
+
+    def get_object(self, *, Bucket, Key):
+        item = (Bucket, Key)
+        if item not in self.objects:
+            raise ClientError("NoSuchKey")
+        return {"Body": Body(self.objects[item]), "ETag": self.etags[item]}
+
+    def put_object(self, *, Bucket, Key, Body, ContentType=None, IfMatch=None, IfNoneMatch=None):
+        self.puts += 1
+        item = (Bucket, Key)
+        current = self.etags.get(item)
+        if IfMatch is not None and current != IfMatch:
+            raise ClientError("PreconditionFailed")
+        if IfNoneMatch == "*" and item in self.objects:
+            raise ClientError("PreconditionFailed")
+        self._counter += 1
+        etag = f'"etag-{self._counter}"'
+        self.objects[item] = Body
+        self.etags[item] = etag
+        return {"ETag": etag}
+
+    def contents(self, bucket, key):
+        return json.loads(self.objects[(bucket, key)].decode())
+
+
+class Body:
+    def __init__(self, data):
+        self.data = data
+
+    def read(self):
+        return self.data
+
+
+class ClientError(Exception):
+    def __init__(self, code):
+        super().__init__(code)
+        self.response = {"Error": {"Code": code}}
+
+
+@pytest.fixture
+def s3():
+    return FakeS3()
+
+
+@pytest.fixture
+def store(s3):
+    return S3StateStore("bucket", "smeggdrop/state", client=s3)
+
+
+def test_from_uri():
+    store = S3StateStore.from_uri("s3://my-bucket/some/prefix", client=object())
+    assert store.bucket == "my-bucket"
+    assert store.prefix == "some/prefix"
+    assert store.key("procs") == "some/prefix/procs.json"
+
+    bare = S3StateStore.from_uri("s3://my-bucket", client=object())
+    assert bare.key("vars") == "vars.json"
+
+    with pytest.raises(ValueError):
+        S3StateStore.from_uri("/not/s3", client=object())
+
+
+def test_missing_state_loads_empty(store):
+    assert store.load("procs") == {}
+
+
+def test_roundtrip(store, s3):
+    store.load("procs")
+    store.save_many("procs", {"greet": "{} {return hi}"})
+    assert s3.contents("bucket", "smeggdrop/state/procs.json") == {"greet": "{} {return hi}"}
+
+    fresh = S3StateStore("bucket", "smeggdrop/state", client=s3)
+    assert fresh.load("procs") == {"greet": "{} {return hi}"}
+
+
+def test_deletions_remove_keys(store, s3):
+    store.load("vars")
+    store.save_many("vars", {"x": "scalar {1}", "y": "scalar {2}"})
+    store.save_many("vars", {"x": None})
+    assert store.load("vars") == {"y": "scalar {2}"}
+
+
+def test_one_put_per_save_not_per_entry(store, s3):
+    store.load("procs")
+    store.save_many("procs", {f"p{i}": "{} {return x}" for i in range(50)})
+    assert s3.puts == 1  # the whole point: not 50 round trips
+
+
+def test_empty_changes_skip_the_write(store, s3):
+    store.load("procs")
+    store.save_many("procs", {})
+    assert s3.puts == 0
+
+
+def test_concurrent_writer_is_merged_not_clobbered(store, s3):
+    store.load("procs")
+    store.save_many("procs", {"mine": "{} {return mine}"})
+
+    # another container defines a different proc against the same state
+    other = S3StateStore("bucket", "smeggdrop/state", client=s3)
+    other.load("procs")
+    other.save_many("procs", {"theirs": "{} {return theirs}"})
+
+    # our next write must not drop theirs
+    store.save_many("procs", {"mine2": "{} {return mine2}"})
+    final = s3.contents("bucket", "smeggdrop/state/procs.json")
+    assert set(final) == {"mine", "theirs", "mine2"}
+
+
+def test_create_is_conditional(store, s3):
+    # a store that never loaded must not blow away an existing object
+    s3.put_object(
+        Bucket="bucket",
+        Key="smeggdrop/state/procs.json",
+        Body=json.dumps({"existing": "{} {return e}"}).encode(),
+    )
+    fresh = S3StateStore("bucket", "smeggdrop/state", client=s3)
+    fresh.save_many("procs", {"new": "{} {return n}"})
+    final = s3.contents("bucket", "smeggdrop/state/procs.json")
+    assert set(final) == {"existing", "new"}
+
+
+def test_unicode_survives(store, s3):
+    store.load("vars")
+    store.save_many("vars", {"emoji": "scalar {✗ ünïcode}"})
+    assert S3StateStore("bucket", "smeggdrop/state", client=s3).load("vars") == {
+        "emoji": "scalar {✗ ünïcode}"
+    }

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,34 @@ revision = 3
 requires-python = ">=3.11"
 
 [[package]]
+name = "boto3"
+version = "1.43.55"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/62/9a6795d2e85b04615a18bf25d39e9cfea243f7bd532f420eeee17045f157/boto3-1.43.55.tar.gz", hash = "sha256:ab2d18d00fd0ceb7110c3659176b9306e009a313dbc5fcc5bd8734253f115157", size = 112686, upload-time = "2026-07-23T19:29:59.448Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/b4/354b0a469e7b215efe4ec9b4ef942ae14becedbfd14bf3f87bf72fb7350a/boto3-1.43.55-py3-none-any.whl", hash = "sha256:c8f23355b4eff538a9c04e09666c6defb5013051de23ca826559906787253188", size = 140026, upload-time = "2026-07-23T19:29:57.897Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.55"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/eb/a235d69083f5948d3ed7e1e5d75ceb16f5bf943761e33b54cb141c497ed1/botocore-1.43.55.tar.gz", hash = "sha256:46e8d9f457a804948abf45a22add963ebaaa6c2765c2f1c26ff3b534309d7a58", size = 15733294, upload-time = "2026-07-23T19:29:48.755Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/23/0c7172020da4ff6d19e6aefa98abc024955dba2c87194b71ac48990d3e84/botocore-1.43.55-py3-none-any.whl", hash = "sha256:b7ceb3070dffb64cc1cfdda3c32db538eb143c46ad9e9e781b0d8f90c9246f37", size = 15417310, upload-time = "2026-07-23T19:29:45.736Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -18,6 +46,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -64,6 +101,39 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/43/35e4d8aa320bffe8287fe8f65f578fa2d2db0a64212f0e710dce58267854/s3transfer-0.19.2.tar.gz", hash = "sha256:ba0309fd86be3c27dbf78cdd813c13c5e1df16e5874b99d2535ebbdfb9892993", size = 165592, upload-time = "2026-07-22T19:30:44.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl", hash = "sha256:d8168eccca828cbb2cd573675333f3bddd254313a9c42494b84c76b539e8ba25", size = 90216, upload-time = "2026-07-22T19:30:43.251Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
 name = "slack-bolt"
 version = "1.30.0"
 source = { registry = "https://pypi.org/simple" }
@@ -90,6 +160,10 @@ version = "0.1.0"
 source = { editable = "." }
 
 [package.optional-dependencies]
+lambda = [
+    { name = "boto3" },
+    { name = "slack-bolt" },
+]
 slack = [
     { name = "slack-bolt" },
 ]
@@ -100,8 +174,21 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "slack-bolt", marker = "extra == 'slack'", specifier = ">=1.20" }]
-provides-extras = ["slack"]
+requires-dist = [
+    { name = "boto3", marker = "extra == 'lambda'", specifier = ">=1.34" },
+    { name = "slack-bolt", marker = "extra == 'lambda'", specifier = ">=1.20" },
+    { name = "slack-bolt", marker = "extra == 'slack'", specifier = ">=1.20" },
+]
+provides-extras = ["slack", "lambda"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=8" }]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]


### PR DESCRIPTION
Stacked on #3, part of #2.

The adapter's decision logic — trigger matching, undoing slack's message mangling (`<url|label>`, html entities, backtick wrapping), reply formatting/chunking, the message handler itself — is plain code with a duck-typed client, so all of it is tested without the sdk. slack_bolt is only imported when wiring the app.

Two run modes:
- `smeggdrop slack` — Socket Mode for local dev, no public endpoint
- `smeggdrop.lambda_handler.handler` — Events API on Lambda via bolt's lazy listeners (ack inside the 3s window, eval in the re-invocation)

Handling untrusted input at the platform edge: request signatures verified by bolt, retried deliveries dropped rather than re-evaluated (a slow eval must not run twice), bot messages never evaluated, channel allowlist via `SMEGGDROP_CHANNELS`.

`Dockerfile.lambda` builds on python:3.13-slim + libtcl8.6; built the image and verified the full engine (safe interp, eval, state) works inside it. Deploy notes in the README — reserved concurrency 1, self-invoke permission for lazy listeners, and state is per-warm-container until the S3 store lands (EFS if durability is needed sooner).