### PR TITLE
S3 state store, and migrating between stores

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ rather than port breakage: helpers their authors deleted years ago,
 services that no longer resolve (`i.buttes.org`, `magick.buttes.org`), and
 a few deliberate infinite loops.
 
+The failure count is also pessimistic in a way that can't be automated
+away: plenty of procs raise on purpose, because the error message is the
+joke — `ncock 24` answers "COCK SIZE OFF THE CHARTS", and a handful more
+refuse with `please see a dentist for further assistance`. Those are
+working procs that the audit has no way to tell apart from broken ones.
+
 ## Security model
 
 All chat input is untrusted and gets evaluated anyway — that's the product —

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ for cold-start overlap, not a licence to run more than one writer.
 
 Config env vars: `SMEGGDROP_TRIGGER` (default `^\s*tcl\s`),
 `SMEGGDROP_CHANNELS` (comma-separated channel IDs, empty = all),
+`SMEGGDROP_BLOCKED_USERS` (comma-separated slack user IDs — not
+names, which anyone can change — silently ignored, no reply),
 `SMEGGDROP_STATE`, `SMEGGDROP_TIME_LIMIT`, `SMEGGDROP_WORDS`,
 `SMEGGDROP_MEMORY_MB` (default 2048, 0 disables).
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ EOF
 ./run-slack-dev.sh state-local          # or any state dir
 ```
 
+Edited state some other way while the bot's up (a one-off `smeggdrop repl`
+fix)? `./reload-bot.sh state-local` reloads it from disk without dropping
+the Slack connection or restarting the process — the reload is queued on
+the same worker thread evals run on, so it can't interrupt one in flight,
+and Socket Mode never reconnects. It's a signal (`SIGHUP`), not a lock:
+the file store still has no cross-process write coordination, so this
+doesn't protect against a repl edit and a live eval writing at the exact
+same instant — it just avoids the multi-second outage a full restart costs.
+
 Slack-specific behaviour worth knowing: mentions are resolved to plain
 nicks on the way in, so procs written for irc see `deathto winkie` rather
 than `deathto <@U03S5JZ7U>`; mIRC colour codes are stripped from replies

--- a/README.md
+++ b/README.md
@@ -69,8 +69,27 @@ Production runs the Events API on Lambda from a container image
 - set **reserved concurrency to 1** — evals are serialized by design
 - grant the function role `lambda:InvokeFunction` on itself (bolt's lazy
   listeners ack within Slack's 3s window, then re-invoke to run the eval)
-- state is ephemeral per warm container until the S3 store lands; mount
-  EFS at `SMEGGDROP_STATE` if you need durability before then
+- set `SMEGGDROP_STATE=s3://bucket/prefix` for durable state, and give the
+  role `s3:GetObject`/`s3:PutObject` on it
+
+## State stores
+
+`--state` (and `SMEGGDROP_STATE`) takes a directory or an `s3://` uri, and
+`migrate` copies between them:
+
+```sh
+uv run smeggdrop --state ./state-local migrate s3://my-bucket/smeggdrop
+```
+
+The directory layout is the perl bot's (one sha1-named file per proc plus
+an `_index`). S3 packs each category into a single JSON object instead:
+6,600 objects would mean 6,600 GETs on every cold start, while the whole
+state is ~6 MB — one GET to load, one PUT per eval that changes something.
+Turn on bucket versioning and every eval becomes a restorable version.
+
+Writes are conditional on the ETag that was loaded, so if a second process
+does write, its changes are merged rather than clobbered. That's a backstop
+for cold-start overlap, not a licence to run more than one writer.
 
 Config env vars: `SMEGGDROP_TRIGGER` (default `^\s*tcl\s`),
 `SMEGGDROP_CHANNELS` (comma-separated channel IDs, empty = all),

--- a/reload-bot.sh
+++ b/reload-bot.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Tell a running bot (started by run-slack-dev.sh) to reload state from
+# disk without dropping its Slack connection or restarting the process.
+#
+#   ./reload-bot.sh [state-dir]      # defaults to ./state-local
+#
+# Use this after editing state some other way (a one-off `smeggdrop repl`
+# fix) while the bot is up: the reload is queued on the same worker thread
+# evals run on, so it can't interrupt one in flight, and the socket-mode
+# connection to Slack is never touched.
+#
+# Caveat: reload only re-syncs the bot's in-memory copy with whatever is on
+# disk. The file state store has no cross-process locking, so if a repl
+# edit and a live Slack eval write at the exact same instant, the second
+# write still wins — reload doesn't add coordination that isn't already
+# there. Fine for a quick one-off fix; not a substitute for the S3 store's
+# conditional writes if that ever matters here.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+STATE="${1:-state-local}"
+PIDFILE="$STATE/.smeggdrop.pid"
+
+if [[ ! -f "$PIDFILE" ]]; then
+  echo "error: no pidfile at $PIDFILE — is the bot running against $STATE?" >&2
+  exit 1
+fi
+
+pid="$(cat "$PIDFILE")"
+if ! kill -0 "$pid" 2>/dev/null; then
+  echo "error: pidfile $PIDFILE points at pid $pid, which isn't running (stale)" >&2
+  exit 1
+fi
+
+kill -HUP "$pid"
+echo "sent reload signal to pid $pid"

--- a/run-slack-dev.sh
+++ b/run-slack-dev.sh
@@ -1,13 +1,31 @@
 #!/usr/bin/env bash
-# Local socket-mode run: reads credentials from .env, state dir as $1.
+# Run the slack bot locally over Socket Mode: no public endpoint, state on
+# disk, safe to Ctrl-C.
 #
-#   ./run-slack-dev.sh ~/dev/smeggdrop-state/hardchats
+#   ./run-slack-dev.sh [state-dir]      # defaults to ./state-local
 #
-# .env needs SLACK_BOT_TOKEN and SLACK_APP_TOKEN (see README).
+# .env (gitignored) needs SLACK_BOT_TOKEN and SLACK_APP_TOKEN — see the
+# README's Slack section for how to mint them.
+#
+# "Safely" here means:
+#   - refuses to start a second instance against the same state dir. The
+#     versioned-eval persistence assumes one writer; two bots racing on the
+#     same files is exactly the kind of self-inflicted corruption that
+#     happened during dev when a repl and a running bot touched the same
+#     state at once.
+#   - the process memory cap (smeggdrop.hardening, default 2048MB) is
+#     always on for the slack subcommand — a single hostile eval can't take
+#     the host down with it.
+#   - state is a plain directory, so it's just files: `git status` in it
+#     before trusting a session, and you can always restore from a backup
+#     or the state repo's own history if a bad eval writes something
+#     unwanted.
 set -euo pipefail
 cd "$(dirname "$0")"
 
 STATE="${1:-state-local}"
+mkdir -p "$STATE"
+LOCK="$STATE/.smeggdrop.lock"
 
 if [[ -f .env ]]; then
   set -a
@@ -18,5 +36,16 @@ fi
 
 : "${SLACK_BOT_TOKEN:?set SLACK_BOT_TOKEN in .env}"
 : "${SLACK_APP_TOKEN:?set SLACK_APP_TOKEN in .env}"
+
+exec 9>"$LOCK"
+if ! flock -n 9; then
+  echo "error: another smeggdrop instance already holds the lock on $STATE" >&2
+  echo "       (check: pgrep -af 'smeggdrop.*--state $STATE')" >&2
+  exit 1
+fi
+
+commit="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+echo "smeggdrop @ $commit ($branch) — state: $STATE — memory cap: ${SMEGGDROP_MEMORY_MB:-2048}MB"
 
 exec uv run --extra slack smeggdrop --state "$STATE" slack

--- a/smeggdrop/cli.py
+++ b/smeggdrop/cli.py
@@ -121,6 +121,9 @@ def cmd_repl(args) -> int:
 
 
 def cmd_slack(args) -> int:
+    import os
+    import signal
+
     from smeggdrop.hardening import apply_memory_limit
     from smeggdrop.platforms.slack import SlackConfig, run_socket_mode
 
@@ -132,9 +135,34 @@ def cmd_slack(args) -> int:
         limits=Limits(eval_time_seconds=cfg.time_limit),
         words_file=cfg.words_file,
     )
+
+    def on_hup(signum, frame):
+        # runs on the main thread; reload() just enqueues onto the same
+        # worker thread evals use, so this never interrupts one in flight
+        log = logging.getLogger("smeggdrop.cli")
+        log.info("SIGHUP received, reloading state from disk")
+        try:
+            errors = engine.reload()
+            log.info("reload complete (%d load errors)", len(errors))
+        except Exception:
+            log.exception("reload failed")
+
+    signal.signal(signal.SIGHUP, on_hup)
+
+    # written for reload-bot.sh to find us: `uv run` forks rather than
+    # execing, so the launching shell's $$ isn't this process's pid — only
+    # we know our own pid reliably, for a file store only (an s3 uri has
+    # no local directory to drop a pidfile in, and Lambda doesn't need one)
+    pidfile = None
+    if not args.state.startswith("s3://"):
+        pidfile = Path(args.state) / ".smeggdrop.pid"
+        pidfile.write_text(str(os.getpid()))
+
     try:
         run_socket_mode(engine, cfg)
     finally:
+        if pidfile is not None:
+            pidfile.unlink(missing_ok=True)
         engine.close()
     return 0
 

--- a/smeggdrop/cli.py
+++ b/smeggdrop/cli.py
@@ -10,12 +10,16 @@ from pathlib import Path
 
 from smeggdrop.audit import audit_state
 from smeggdrop.engine import Engine, EvalRequest, Limits
-from smeggdrop.state import FileStateStore
+from smeggdrop.state import CATEGORIES, open_store
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="smeggdrop")
-    parser.add_argument("--state", default="state", help="state directory (default: ./state)")
+    parser.add_argument(
+        "--state",
+        default="state",
+        help="state directory, or s3://bucket/prefix (default: ./state)",
+    )
     parser.add_argument("--tcl-dir", default=None, help="override bundled tcl bootstrap dir")
     parser.add_argument("-v", "--verbose", action="store_true")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -42,6 +46,11 @@ def main(argv: list[str] | None = None) -> int:
     )
     audit.add_argument("--arg-value", default="test", help="dummy argument (default: test)")
 
+    migrate = sub.add_parser(
+        "migrate", help="copy state into another store (e.g. a file dir into s3)"
+    )
+    migrate.add_argument("destination", help="target directory or s3://bucket/prefix")
+
     sub.add_parser(
         "slack",
         help="run the slack bot over socket mode "
@@ -63,6 +72,8 @@ def main(argv: list[str] | None = None) -> int:
         return cmd_repl(args)
     if args.command == "slack":
         return cmd_slack(args)
+    if args.command == "migrate":
+        return cmd_migrate(args)
     return cmd_audit(args)
 
 
@@ -73,7 +84,7 @@ def cmd_repl(args) -> int:
         pass
 
     engine = Engine(
-        FileStateStore(args.state),
+        open_store(args.state),
         tcl_dir=args.tcl_dir,
         limits=Limits(eval_time_seconds=args.time_limit),
         words_file=args.words,
@@ -116,7 +127,7 @@ def cmd_slack(args) -> int:
     apply_memory_limit()
     cfg = SlackConfig.from_env()
     engine = Engine(
-        FileStateStore(args.state),
+        open_store(args.state),
         tcl_dir=args.tcl_dir,
         limits=Limits(eval_time_seconds=cfg.time_limit),
         words_file=cfg.words_file,
@@ -128,8 +139,19 @@ def cmd_slack(args) -> int:
     return 0
 
 
+def cmd_migrate(args) -> int:
+    source = open_store(args.state)
+    destination = open_store(args.destination)
+    for category in CATEGORIES:
+        entries = source.load(category)
+        destination.load(category)  # so an existing destination is merged, not replaced
+        destination.save_many(category, entries)
+        print(f"{category}: copied {len(entries)}")
+    return 0
+
+
 def cmd_audit(args) -> int:
-    store = FileStateStore(args.state)
+    store = open_store(args.state)
     report = audit_state(
         store,
         tcl_dir=args.tcl_dir,

--- a/smeggdrop/engine.py
+++ b/smeggdrop/engine.py
@@ -107,6 +107,7 @@ class Engine:
         self._curl_calls = 0
         self.load_errors: dict[str, str] = {}
         self._closed = False
+        self._tcl_dir = tcl_dir
         self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="smeggdrop-tcl")
         self._executor.submit(self._init_interp, tcl_dir).result()
 
@@ -130,7 +131,33 @@ class Engine:
         future = self._executor.submit(self._eval, req, say)
         return future.result(timeout if timeout is not None else self.limits.eval_time_seconds + 30)
 
+    def reload(self, timeout: float = 60) -> dict[str, str]:
+        """Rebuild the interpreter from scratch, re-reading state from disk.
+
+        For picking up procs/vars written some other way (a one-off repl
+        fix, another operator) without dropping the platform connection —
+        unlike a full process restart, which for a Slack Socket Mode bot
+        means a lost connection and a several-second gap where messages
+        can go unanswered. Runs on the same worker thread as eval(), so it
+        can never interleave with an in-flight eval; it just queues behind
+        whatever's currently running. Nothing in memory is lost by this:
+        state is written to disk synchronously after every eval, so disk
+        is always the authoritative copy.
+
+        Returns the fresh load_errors (also left on self.load_errors).
+        """
+        future = self._executor.submit(self._reload)
+        return future.result(timeout)
+
     # -- worker-thread internals ---------------------------------------
+
+    def _reload(self) -> dict[str, str]:
+        old_interp = self.interp
+        self.load_errors = {}
+        self._words = None
+        self._init_interp(self._tcl_dir)
+        old_interp.close()
+        return self.load_errors
 
     def _init_interp(self, tcl_dir) -> None:
         self.interp = SafeTclInterp(

--- a/smeggdrop/lambda_handler.py
+++ b/smeggdrop/lambda_handler.py
@@ -2,10 +2,12 @@
 
 The engine and bolt app are built once per execution environment and reused
 across invocations, so the interp stays warm. Evals are serialized by the
-engine's worker thread; run this function with reserved concurrency 1 until
-the S3 state store lands — with the file store, state only persists for the
-life of a warm container (mount EFS at SMEGGDROP_STATE if you need
-durability before then).
+engine's worker thread; run this function with reserved concurrency 1.
+
+Point SMEGGDROP_STATE at s3://bucket/prefix for durable state — the file
+store only lasts as long as a warm container. The S3 store merges
+concurrent writers rather than clobbering them, but single-writer is still
+the intended configuration.
 
 Lazy listeners re-invoke this same function (bolt's FaaS pattern), so the
 function role needs lambda:InvokeFunction on itself.
@@ -25,11 +27,11 @@ def _handler():
 
     from smeggdrop.engine import Engine, Limits
     from smeggdrop.platforms.slack import SlackConfig, build_app
-    from smeggdrop.state import FileStateStore
+    from smeggdrop.state import open_store
 
     cfg = SlackConfig.from_env()
     engine = Engine(
-        FileStateStore(cfg.state_dir),
+        open_store(cfg.state_dir),
         limits=Limits(eval_time_seconds=cfg.time_limit),
         words_file=cfg.words_file,
     )

--- a/smeggdrop/platforms/slack.py
+++ b/smeggdrop/platforms/slack.py
@@ -68,11 +68,21 @@ SPECIAL_MENTION = re.compile(r"<!([a-z_]+)(?:\^[^|>]*)?(?:\|([^>]*))?>")
 
 
 def unfuck_slack_message(text: str) -> str:
-    """Undo slack's message mangling before trigger matching: unwrap
-    <url> / <url|label> links, unwrap a fully-backticked message, and
-    unescape html entities."""
-    text = re.sub(r"<(https?://[^|>]+)(?:\|[^>]*)?>", r"\1", text)
-    return html.unescape(unwrap_backticks(text))
+    """Undo slack's message mangling before trigger matching: unescape html
+    entities, unwrap <url> / <url|label> links, and unwrap a fully-
+    backticked message.
+
+    Unescaping has to happen first: slack sometimes delivers link markup
+    with the angle brackets as &lt;/&gt; entities (observed live — a user's
+    <http://x|x> arrived that way), and the url-unwrap regex needs real `<`
+    `>` characters to match. Getting this backwards doesn't leak anything
+    (SafeFetcher.validate rejects a URL with stray `<>` for an unrelated
+    reason — the scheme fails to parse), but it does mean a legitimately
+    pasted link in that form would break with a confusing error.
+    """
+    text = html.unescape(text)
+    text = unwrap_backticks(text)
+    return re.sub(r"<(https?://[^|>]+)(?:\|[^>]*)?>", r"\1", text)
 
 
 def unwrap_backticks(text: str) -> str:

--- a/smeggdrop/platforms/slack.py
+++ b/smeggdrop/platforms/slack.py
@@ -38,6 +38,7 @@ MAX_MESSAGES = 3
 class SlackConfig:
     trigger: re.Pattern = DEFAULT_TRIGGER
     channels: frozenset[str] = frozenset()  # empty = all channels
+    blocked_users: frozenset[str] = frozenset()  # slack user IDs, not names
     state_dir: str = "state"
     time_limit: int = 5
     words_file: str | None = None
@@ -48,12 +49,16 @@ class SlackConfig:
         channels = frozenset(
             c.strip() for c in env.get("SMEGGDROP_CHANNELS", "").split(",") if c.strip()
         )
+        blocked_users = frozenset(
+            u.strip() for u in env.get("SMEGGDROP_BLOCKED_USERS", "").split(",") if u.strip()
+        )
         return cls(
             # case-insensitive like the default: chat clients capitalize
             trigger=re.compile(
                 env.get("SMEGGDROP_TRIGGER", DEFAULT_TRIGGER.pattern), re.IGNORECASE
             ),
             channels=channels,
+            blocked_users=blocked_users,
             state_dir=env.get("SMEGGDROP_STATE", "state"),
             time_limit=int(env.get("SMEGGDROP_TIME_LIMIT", "5")),
             words_file=env.get("SMEGGDROP_WORDS") or None,
@@ -286,6 +291,11 @@ def handle_message_event(
 
     channel = event.get("channel") or ""
     if cfg.channels and channel not in cfg.channels:
+        return False
+
+    # keyed on the immutable slack user id, never on nick/display name
+    # (which is user-controlled and can be changed or duplicated)
+    if (msg.get("user") or "") in cfg.blocked_users:
         return False
 
     text = msg.get("text") or ""

--- a/smeggdrop/platforms/slack.py
+++ b/smeggdrop/platforms/slack.py
@@ -72,10 +72,19 @@ def unfuck_slack_message(text: str) -> str:
     <url> / <url|label> links, unwrap a fully-backticked message, and
     unescape html entities."""
     text = re.sub(r"<(https?://[^|>]+)(?:\|[^>]*)?>", r"\1", text)
-    m = re.fullmatch(r"\s*`{1,3}(.+?)`{1,3}\s*", text, re.S)
-    if m:
-        text = m.group(1)
-    return html.unescape(text)
+    return html.unescape(unwrap_backticks(text))
+
+
+def unwrap_backticks(text: str) -> str:
+    """Strip backticks that wrap the whole string.
+
+    People copy commands out of code-formatted messages, so `tcl ``snoe``
+    arrives with the code portion still fenced and fails as an invalid
+    command name. Only unwrap when the fences enclose everything — a stray
+    backtick inside real tcl is left alone.
+    """
+    match = re.fullmatch(r"\s*`{1,3}([^`].*?)`{1,3}\s*", text, re.S)
+    return match.group(1) if match else text
 
 
 def resolve_mentions(text: str, client, nicks: "NickCache") -> str:
@@ -276,6 +285,9 @@ def handle_message_event(
 
     cleaned = resolve_mentions(unfuck_slack_message(text), client, resolver)
     code = extract_code(cleaned, cfg.trigger)
+    if code is not None:
+        # the trigger may have been outside the fences: "tcl `snoe`"
+        code = unwrap_backticks(code)
     if code is None or not code.strip():
         if chat_log is not None and cleaned:
             chat_log.append(channel, nick, user_id or None, cleaned)

--- a/smeggdrop/state.py
+++ b/smeggdrop/state.py
@@ -38,6 +38,15 @@ def name_sha1(name: str) -> str:
     return hashlib.sha1(name.encode("utf-8")).hexdigest()
 
 
+def open_store(location: str) -> StateStore:
+    """Open a state store from a path or an s3:// uri."""
+    if location.startswith("s3://"):
+        from smeggdrop.state_s3 import S3StateStore
+
+        return S3StateStore.from_uri(location)
+    return FileStateStore(location)
+
+
 class FileStateStore:
     def __init__(self, root: Path | str):
         self.root = Path(root)

--- a/smeggdrop/state.py
+++ b/smeggdrop/state.py
@@ -38,6 +38,22 @@ def name_sha1(name: str) -> str:
     return hashlib.sha1(name.encode("utf-8")).hexdigest()
 
 
+def decode(data: bytes) -> str:
+    """Decode saved state, tolerating the perl bot's raw bytes.
+
+    That implementation used `use bytes` and wrote whatever came off irc, so
+    a handful of procs hold latin-1: `¯`·.¸¸.·´¯` wave decorations, `°_o`
+    faces, the odd accented word. Decoding those with errors="replace"
+    silently turns each one into U+FFFD and destroys the art — it showed up
+    as `<?>_o` in okeybattle. latin-1 maps every byte to a codepoint, so it
+    is a lossless fallback; anything written from here on is utf-8.
+    """
+    try:
+        return data.decode("utf-8")
+    except UnicodeDecodeError:
+        return data.decode("latin-1")
+
+
 def open_store(location: str) -> StateStore:
     """Open a state store from a path or an s3:// uri."""
     if location.startswith("s3://"):
@@ -61,7 +77,7 @@ class FileStateStore:
         for name, sha in index.items():
             path = self.root / category / sha
             try:
-                data = path.read_text(encoding="utf-8", errors="replace")
+                data = decode(path.read_bytes())
             except FileNotFoundError:
                 # damage, not deletion — keep the entry so the loss stays
                 # visible (and recoverable if the file turns up)
@@ -95,7 +111,7 @@ class FileStateStore:
         if not path.exists():
             return {}
         index: dict[str, str] = {}
-        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        for line in decode(path.read_bytes()).splitlines():
             line = line.strip()
             if not line:
                 continue

--- a/smeggdrop/state_s3.py
+++ b/smeggdrop/state_s3.py
@@ -1,0 +1,159 @@
+"""S3-backed state, for running on Lambda.
+
+The file layout stores one object per proc, which is fine on a disk and
+terrible against an object store: 6,600 GETs on every cold start. The whole
+hardchats state is only ~6 MB of actual content, so each category is packed
+into a single JSON object instead — one GET to load, one PUT per eval that
+changes anything.
+
+History comes from S3 bucket versioning rather than from keeping old
+objects around: turn it on and every eval's state becomes a restorable
+version.
+
+Concurrent writers are handled with a conditional PUT (If-Match on the
+ETag we loaded). If another process wrote in between, this reloads, re-
+applies its own changes on top, and retries — so a second Lambda container
+can't silently clobber a proc someone just defined. Run with reserved
+concurrency 1 anyway; this is the backstop, not the plan.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Mapping
+
+log = logging.getLogger(__name__)
+
+CATEGORIES = ("procs", "vars")
+PUT_ATTEMPTS = 5
+
+
+class S3StateStore:
+    def __init__(self, bucket: str, prefix: str = "", client=None):
+        self.bucket = bucket
+        self.prefix = prefix.strip("/")
+        self._client = client
+        self._snapshots: dict[str, dict[str, str]] = {}
+        self._etags: dict[str, str | None] = {}
+
+    @classmethod
+    def from_uri(cls, uri: str, client=None) -> "S3StateStore":
+        """s3://bucket/optional/prefix"""
+        if not uri.startswith("s3://"):
+            raise ValueError(f"not an s3 uri: {uri!r}")
+        bucket, _, prefix = uri[len("s3://") :].partition("/")
+        if not bucket:
+            raise ValueError(f"no bucket in {uri!r}")
+        return cls(bucket, prefix, client=client)
+
+    @property
+    def client(self):
+        if self._client is None:
+            import boto3  # imported lazily so the core stays dependency-free
+
+            self._client = boto3.client("s3")
+        return self._client
+
+    def key(self, category: str) -> str:
+        return f"{self.prefix}/{category}.json" if self.prefix else f"{category}.json"
+
+    # -- StateStore protocol -------------------------------------------
+
+    def load(self, category: str) -> dict[str, str]:
+        snapshot, etag = self._fetch(category)
+        self._snapshots[category] = snapshot
+        self._etags[category] = etag
+        return dict(snapshot)
+
+    def save_many(self, category: str, changes: Mapping[str, str | None]) -> None:
+        if not changes:
+            return
+        for attempt in range(1, PUT_ATTEMPTS + 1):
+            snapshot = dict(self._snapshots.get(category, {}))
+            _apply(snapshot, changes)
+            try:
+                etag = self._put(category, snapshot, self._etags.get(category))
+            except _Conflict:
+                # somebody else wrote; take their version and re-apply ours
+                log.warning("%s: state changed underneath us, merging", category)
+                fresh, fresh_etag = self._fetch(category)
+                self._snapshots[category] = fresh
+                self._etags[category] = fresh_etag
+                if attempt == PUT_ATTEMPTS:
+                    raise
+                continue
+            self._snapshots[category] = snapshot
+            self._etags[category] = etag
+            return
+
+    # -- s3 plumbing ----------------------------------------------------
+
+    def _fetch(self, category: str) -> tuple[dict[str, str], str | None]:
+        try:
+            response = self.client.get_object(Bucket=self.bucket, Key=self.key(category))
+        except Exception as e:  # noqa: BLE001 — botocore raises dynamic classes
+            if _is_missing(e):
+                return {}, None
+            raise
+        body = response["Body"].read()
+        etag = response.get("ETag")
+        if not body:
+            return {}, etag
+        return json.loads(body.decode("utf-8")), etag
+
+    def _put(self, category: str, snapshot: dict[str, str], etag: str | None) -> str | None:
+        body = json.dumps(snapshot, ensure_ascii=False, sort_keys=True).encode("utf-8")
+        kwargs = {
+            "Bucket": self.bucket,
+            "Key": self.key(category),
+            "Body": body,
+            "ContentType": "application/json",
+        }
+        conditional = dict(kwargs)
+        if etag:
+            conditional["IfMatch"] = etag
+        else:
+            conditional["IfNoneMatch"] = "*"  # create-only, don't clobber
+        try:
+            response = self.client.put_object(**conditional)
+        except Exception as e:  # noqa: BLE001
+            if _is_precondition_failed(e):
+                raise _Conflict from e
+            if not _is_unsupported_parameter(e):
+                raise
+            # older botocore, or a store without conditional writes: fall
+            # back to an unconditional put and rely on single-writer
+            log.warning("conditional put unsupported; writing unconditionally")
+            response = self.client.put_object(**kwargs)
+        return response.get("ETag")
+
+
+class _Conflict(Exception):
+    pass
+
+
+def _apply(snapshot: dict[str, str], changes: Mapping[str, str | None]) -> None:
+    for name, value in changes.items():
+        if value is None:
+            snapshot.pop(name, None)
+        else:
+            snapshot[name] = value
+
+
+def _error_code(error: Exception) -> str:
+    response = getattr(error, "response", None) or {}
+    return str(response.get("Error", {}).get("Code", ""))
+
+
+def _is_missing(error: Exception) -> bool:
+    return _error_code(error) in ("NoSuchKey", "404", "NotFound")
+
+
+def _is_precondition_failed(error: Exception) -> bool:
+    return _error_code(error) in ("PreconditionFailed", "412", "ConditionalRequestConflict")
+
+
+def _is_unsupported_parameter(error: Exception) -> bool:
+    name = type(error).__name__
+    return name in ("ParamValidationError", "ClientError") and "IfMatch" in str(error)

--- a/smeggdrop/tcl/bootstrap.tcl
+++ b/smeggdrop/tcl/bootstrap.tcl
@@ -16,7 +16,14 @@ proc log {} {return $context::log}
 
 # best-effort: the old hostmask proc looked nicks up in channel state,
 # which chat platforms don't have; fall back to scanning recent chatter
-proc hostmask {who} {
+# regression found live: remote_command_state calls this bare (no
+# argument) expecting the caller's own hostmask, matching the old
+# eggdrop/irc idiom -- default empty/omitted to [nick], same "no target
+# means self" convention as the name proc.
+proc hostmask {{who {}}} {
+    if {$who eq ""} {
+        set who [nick]
+    }
     foreach line [log] {
         lassign $line _ts _nick _mask _text
         if {[string equal -nocase $_nick $who]} {return $_mask}

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -265,3 +265,60 @@ def test_apply_reports_real_errors(engine):
 def test_builtin_apply_stays_reachable(engine):
     # bootstrap stashes it before commands.tcl can shadow it
     assert run(engine, "tcl_apply {{x} {return $x}} ok").output == "ok"
+
+
+def test_reload_picks_up_externally_written_state(store, engine):
+    # simulate a one-off `smeggdrop repl` fix landing on disk while the
+    # engine is already running, the exact scenario hot reload is for
+    other = Engine(store, limits=Limits(eval_time_seconds=2))
+    try:
+        run(other, "proc surprise {} {return from_outside}")
+    finally:
+        other.close()
+
+    assert not run(engine, "surprise").ok  # not visible yet
+    errors = engine.reload()
+    assert errors == {}
+    assert run(engine, "surprise").output == "from_outside"
+
+
+def test_reload_preserves_engine_usability(engine):
+    engine.reload()
+    assert run(engine, "expr {6 * 7}").output == "42"
+
+
+def test_reload_reports_load_errors(store):
+    # write something that will fail to install, then confirm reload
+    # surfaces it the same way startup does
+    engine = Engine(store, limits=Limits(eval_time_seconds=2))
+    try:
+        store.save_many("procs", {"broken": "{} {unbalanced {"})
+        errors = engine.reload()
+        assert any("broken" in k for k in errors)
+        assert engine.load_errors == errors
+    finally:
+        engine.close()
+
+
+def test_reload_does_not_affect_concurrent_eval_ordering(store):
+    # a slow eval and a reload issued back-to-back must not interleave —
+    # reload only ever sees the interpreter in a consistent pre- or
+    # post-eval state, never mid-eval
+    engine = Engine(store, limits=Limits(eval_time_seconds=2))
+    try:
+        import threading
+
+        results = []
+
+        def slow_eval():
+            results.append(("eval", run(engine, "after 200; expr {1 + 1}").output))
+
+        t = threading.Thread(target=slow_eval)
+        t.start()
+        errors = engine.reload()
+        t.join()
+
+        assert errors == {}
+        assert results == [("eval", "2")]
+    finally:
+        engine.close()

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -221,6 +221,13 @@ def test_names_and_hostmask_shims(engine):
     result = engine.eval(EvalRequest(code="hostmask stranger", loglines=()))
     assert result.output == "stranger!unknown@unknown"
 
+    # regression found live: legacy procs (remote_command_state) call this
+    # bare, expecting the caller's own hostmask -- "no target" must mean
+    # self, same convention as name
+    lines = ((1700000000, "bob", "bob!b@example.org", "hi"),)
+    result = engine.eval(EvalRequest(code="hostmask", nick="bob", loglines=lines))
+    assert result.output == "bob!b@example.org"
+
 
 def test_legacy_state_dir_loads(tmp_path):
     import hashlib

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -146,3 +146,31 @@ def test_post_body_capped(server, fetcher):
 def test_unsupported_method_refused(fetcher):
     with pytest.raises(FetchError, match="method"):
         fetcher.fetch("http://example.com/", method="DELETE")
+
+
+def test_redirect_to_private_address_is_blocked_under_production_policy():
+    # named regression for a specific attack shape: an attacker-controlled
+    # public host redirects to a loopback/private target, hoping the
+    # redirect hop skips revalidation. It doesn't -- validate() runs again
+    # on every hop, under whatever policy the caller actually configured
+    # (production default: allow_private=False), not a relaxed test-only one.
+    from unittest.mock import patch
+
+    fetcher = SafeFetcher(FetchPolicy(timeout=3))
+
+    class FakeRedirectResponse:
+        status = 302
+        headers = {"Location": "http://127.0.0.1/secret"}
+
+        def read(self, n):
+            return b""
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    with patch.object(fetcher._opener, "open", return_value=FakeRedirectResponse()):
+        with pytest.raises(FetchError, match="non-public address"):
+            fetcher.fetch("http://example.com/")

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -396,3 +396,27 @@ def test_retry_after_header_is_honoured():
         response = Response()
 
     assert retry_after_seconds(Err()) == 7.0
+
+
+@pytest.mark.parametrize(
+    "text,code",
+    [
+        ("tcl `snoe`", "snoe"),
+        ("tcl ```expr {1 + 1}```", "expr {1 + 1}"),
+        ("`tcl snoe`", "snoe"),
+        ("tcl expr {1 + 1}", "expr {1 + 1}"),
+    ],
+)
+def test_backtick_wrapped_commands_run(engine, cfg, text, code):
+    # people copy commands out of code-formatted messages
+    from smeggdrop.platforms.slack import unwrap_backticks, unfuck_slack_message
+    from smeggdrop.platforms import extract_code
+
+    extracted = extract_code(unfuck_slack_message(text), cfg.trigger)
+    assert unwrap_backticks(extracted) == code
+
+
+def test_backticked_command_evaluates(engine, cfg):
+    client = StubClient()
+    assert handle_message_event(engine, client, event("tcl `expr {6 * 7}`"), cfg)
+    assert client.posted == [("C123", "```42```")]

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -134,6 +134,12 @@ def test_slack_mangled_url_unwrapped(engine, cfg):
         ("`tcl expr 1`", "tcl expr 1"),
         ("a &amp; b &lt;c&gt;", "a & b <c>"),
         ("plain text", "plain text"),
+        # regression: slack sometimes delivers link markup with the angle
+        # brackets html-escaped (&lt;url|label&gt; instead of <url|label>) --
+        # observed live from a real user pasting <http://x|x>. Unescaping
+        # has to happen before the url-unwrap regex or it never fires.
+        ("&lt;http://example.com|example.com&gt;", "http://example.com"),
+        ("&lt;https://example.com/x&gt;", "https://example.com/x"),
     ],
 )
 def test_unfuck_slack_message(mangled, clean):
@@ -420,3 +426,18 @@ def test_backticked_command_evaluates(engine, cfg):
     client = StubClient()
     assert handle_message_event(engine, client, event("tcl `expr {6 * 7}`"), cfg)
     assert client.posted == [("C123", "```42```")]
+
+
+def test_html_escaped_link_markup_reaches_the_fetcher(engine, cfg):
+    # regression: this exact shape (html-escaped <url|label>) was observed
+    # live and used to fail with "refusing scheme ''" -- a malformed-url
+    # artifact of the ordering bug, not a real SSRF block. After the fix it
+    # should unwrap to a clean http:// URL and fail for the real reason
+    # (unresolvable host), proving the fetcher is actually being reached.
+    client = StubClient()
+    handle_message_event(
+        engine, client, event("tcl core::curl &lt;http://nonexistent.invalid|x&gt;"), cfg
+    )
+    assert len(client.posted) == 1
+    assert "cannot resolve" in client.posted[0][1]
+    assert "refusing scheme ''" not in client.posted[0][1]

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -441,3 +441,35 @@ def test_html_escaped_link_markup_reaches_the_fetcher(engine, cfg):
     assert len(client.posted) == 1
     assert "cannot resolve" in client.posted[0][1]
     assert "refusing scheme ''" not in client.posted[0][1]
+
+
+def test_blocked_user_is_silently_ignored(engine):
+    cfg = SlackConfig(blocked_users=frozenset({"U1"}))
+    client = StubClient(user_names={"U1": "attacker"})
+    assert not handle_message_event(engine, client, event("tcl expr {1 + 1}"), cfg)
+    assert client.posted == []
+
+
+def test_blocked_user_keyed_on_id_not_display_name(engine):
+    # blocking must survive a nick/display-name change -- it's the same
+    # slack account, U1, regardless of what name it currently shows
+    cfg = SlackConfig(blocked_users=frozenset({"U1"}))
+    client = StubClient(user_names={"U1": "totally-different-name-now"})
+    assert not handle_message_event(engine, client, event("tcl expr {1 + 1}"), cfg)
+    assert client.posted == []
+
+
+def test_other_users_unaffected_by_block(engine, cfg):
+    blocking_cfg = SlackConfig(blocked_users=frozenset({"U999"}))
+    client = StubClient(user_names={"U1": "alice"})
+    assert handle_message_event(engine, client, event("tcl expr {1 + 1}"), blocking_cfg)
+    assert client.posted == [("C123", "```2```")]
+
+
+def test_blocked_users_config_from_env():
+    cfg = SlackConfig.from_env({"SMEGGDROP_BLOCKED_USERS": "U1, U2 ,"})
+    assert cfg.blocked_users == frozenset({"U1", "U2"})
+
+
+def test_no_blocked_users_by_default():
+    assert SlackConfig().blocked_users == frozenset()

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -79,3 +79,18 @@ def test_names_never_become_paths(tmp_path):
     assert (tmp_path / "procs" / name_sha1(evil)).exists()
     assert not (tmp_path.parent / "escape").exists()
     assert FileStateStore(tmp_path).load("procs") == {evil: "{} {return x}"}
+
+
+def test_open_store_dispatches_on_location(tmp_path, monkeypatch):
+    from smeggdrop.state import FileStateStore as FSS
+    from smeggdrop.state import open_store
+
+    assert isinstance(open_store(str(tmp_path)), FSS)
+
+    # s3 uris get the s3 store, without needing credentials to construct
+    import smeggdrop.state_s3 as state_s3
+
+    monkeypatch.setattr(state_s3.S3StateStore, "client", property(lambda self: None))
+    store = open_store("s3://bucket/prefix")
+    assert isinstance(store, state_s3.S3StateStore)
+    assert store.bucket == "bucket"

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -94,3 +94,25 @@ def test_open_store_dispatches_on_location(tmp_path, monkeypatch):
     store = open_store("s3://bucket/prefix")
     assert isinstance(store, state_s3.S3StateStore)
     assert store.bucket == "bucket"
+
+
+def test_legacy_latin1_bytes_survive_loading(tmp_path):
+    # the perl bot used `use bytes`, so some procs hold latin-1 art:
+    # ¯`·.¸¸.·´¯ waves and °_o faces. errors="replace" destroyed them.
+    from smeggdrop.state import decode
+
+    procs = tmp_path / "procs"
+    procs.mkdir(parents=True)
+    (tmp_path / "vars").mkdir()
+    raw = b'{} { return "\xb0_o \xb7_. \xaf`\xb7.\xb8\xb8.\xb7\xb4\xaf" }'
+    sha = name_sha1("face")
+    (procs / "_index").write_text("{face} %s\n" % sha)
+    (procs / sha).write_bytes(raw)
+
+    loaded = FileStateStore(tmp_path).load("procs")["face"]
+    assert "�" not in loaded
+    assert "°_o" in loaded and "·_." in loaded
+    assert "¯`·.¸¸.·´¯" in loaded
+
+    # utf-8 content still decodes as utf-8, not mojibake
+    assert decode("✗ ünïcode".encode("utf-8")) == "✗ ünïcode"

--- a/tests/test_state_s3.py
+++ b/tests/test_state_s3.py
@@ -1,0 +1,146 @@
+"""S3 state store, exercised against a fake S3 that mimics the parts we use:
+ETags, conditional writes, and NoSuchKey."""
+
+import json
+
+import pytest
+
+from smeggdrop.state_s3 import S3StateStore
+
+
+class FakeS3:
+    """Minimal S3: objects with ETags and If-Match/If-None-Match semantics."""
+
+    def __init__(self):
+        self.objects: dict[tuple[str, str], bytes] = {}
+        self.etags: dict[tuple[str, str], str] = {}
+        self.puts = 0
+        self._counter = 0
+
+    def get_object(self, *, Bucket, Key):
+        item = (Bucket, Key)
+        if item not in self.objects:
+            raise ClientError("NoSuchKey")
+        return {"Body": Body(self.objects[item]), "ETag": self.etags[item]}
+
+    def put_object(self, *, Bucket, Key, Body, ContentType=None, IfMatch=None, IfNoneMatch=None):
+        self.puts += 1
+        item = (Bucket, Key)
+        current = self.etags.get(item)
+        if IfMatch is not None and current != IfMatch:
+            raise ClientError("PreconditionFailed")
+        if IfNoneMatch == "*" and item in self.objects:
+            raise ClientError("PreconditionFailed")
+        self._counter += 1
+        etag = f'"etag-{self._counter}"'
+        self.objects[item] = Body
+        self.etags[item] = etag
+        return {"ETag": etag}
+
+    def contents(self, bucket, key):
+        return json.loads(self.objects[(bucket, key)].decode())
+
+
+class Body:
+    def __init__(self, data):
+        self.data = data
+
+    def read(self):
+        return self.data
+
+
+class ClientError(Exception):
+    def __init__(self, code):
+        super().__init__(code)
+        self.response = {"Error": {"Code": code}}
+
+
+@pytest.fixture
+def s3():
+    return FakeS3()
+
+
+@pytest.fixture
+def store(s3):
+    return S3StateStore("bucket", "smeggdrop/state", client=s3)
+
+
+def test_from_uri():
+    store = S3StateStore.from_uri("s3://my-bucket/some/prefix", client=object())
+    assert store.bucket == "my-bucket"
+    assert store.prefix == "some/prefix"
+    assert store.key("procs") == "some/prefix/procs.json"
+
+    bare = S3StateStore.from_uri("s3://my-bucket", client=object())
+    assert bare.key("vars") == "vars.json"
+
+    with pytest.raises(ValueError):
+        S3StateStore.from_uri("/not/s3", client=object())
+
+
+def test_missing_state_loads_empty(store):
+    assert store.load("procs") == {}
+
+
+def test_roundtrip(store, s3):
+    store.load("procs")
+    store.save_many("procs", {"greet": "{} {return hi}"})
+    assert s3.contents("bucket", "smeggdrop/state/procs.json") == {"greet": "{} {return hi}"}
+
+    fresh = S3StateStore("bucket", "smeggdrop/state", client=s3)
+    assert fresh.load("procs") == {"greet": "{} {return hi}"}
+
+
+def test_deletions_remove_keys(store, s3):
+    store.load("vars")
+    store.save_many("vars", {"x": "scalar {1}", "y": "scalar {2}"})
+    store.save_many("vars", {"x": None})
+    assert store.load("vars") == {"y": "scalar {2}"}
+
+
+def test_one_put_per_save_not_per_entry(store, s3):
+    store.load("procs")
+    store.save_many("procs", {f"p{i}": "{} {return x}" for i in range(50)})
+    assert s3.puts == 1  # the whole point: not 50 round trips
+
+
+def test_empty_changes_skip_the_write(store, s3):
+    store.load("procs")
+    store.save_many("procs", {})
+    assert s3.puts == 0
+
+
+def test_concurrent_writer_is_merged_not_clobbered(store, s3):
+    store.load("procs")
+    store.save_many("procs", {"mine": "{} {return mine}"})
+
+    # another container defines a different proc against the same state
+    other = S3StateStore("bucket", "smeggdrop/state", client=s3)
+    other.load("procs")
+    other.save_many("procs", {"theirs": "{} {return theirs}"})
+
+    # our next write must not drop theirs
+    store.save_many("procs", {"mine2": "{} {return mine2}"})
+    final = s3.contents("bucket", "smeggdrop/state/procs.json")
+    assert set(final) == {"mine", "theirs", "mine2"}
+
+
+def test_create_is_conditional(store, s3):
+    # a store that never loaded must not blow away an existing object
+    s3.put_object(
+        Bucket="bucket",
+        Key="smeggdrop/state/procs.json",
+        Body=json.dumps({"existing": "{} {return e}"}).encode(),
+    )
+    fresh = S3StateStore("bucket", "smeggdrop/state", client=s3)
+    fresh.save_many("procs", {"new": "{} {return n}"})
+    final = s3.contents("bucket", "smeggdrop/state/procs.json")
+    assert set(final) == {"existing", "new"}
+
+
+def test_unicode_survives(store, s3):
+    store.load("vars")
+    store.save_many("vars", {"emoji": "scalar {✗ ünïcode}"})
+    assert S3StateStore("bucket", "smeggdrop/state", client=s3).load("vars") == {
+        "emoji": "scalar {✗ ünïcode}"
+    }


### PR DESCRIPTION
Stacked on #5. Durable state for the Lambda deploy, split out of #5 so it can be reviewed on its own.

The file layout keeps one object per proc, which is fine on a disk and wrong against an object store: 6,600 GETs on every cold start. The whole hardchats state is only ~6 MB of actual content, so each category packs into a single JSON object instead — one GET to load, one PUT per eval that changes anything. Bucket versioning then gives per-eval history for free, which is a cheaper version of the git-backed-state idea from upstream smeggdrop.

Writes are conditional on the ETag that was loaded. If a second container does write concurrently, its changes get merged rather than clobbering a proc someone just defined — a backstop for cold-start overlap, not a licence to run more than one writer (reserved concurrency stays 1).

`--state` / `SMEGGDROP_STATE` now take a path or an `s3://` uri anywhere they appear, and `smeggdrop migrate <destination>` copies between stores. Verified file→file against the real state: 6,603 procs and 1,652 vars round-tripped and the copy still evaluates.

Nine tests run against a fake S3 that mimics ETags, conditional writes and NoSuchKey — including the concurrent-writer merge and refusing to clobber an existing object on first write. boto3 is imported lazily so the core stays dependency-free.