### PR TITLE
Retain state versions and back the bucket up

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,14 @@ Writes are conditional on the ETag that was loaded, so if a second process
 does write, its changes are merged rather than clobbered. That's a backstop
 for cold-start overlap, not a licence to run more than one writer.
 
+Packing per category cuts cold-start GETs, but it also means every eval
+that changes anything rewrites a whole ~6 MB blob, so versions pile up per
+*eval*, not per changed proc. The deployed bucket keeps the 200 most recent
+noncurrent versions and expires them after 90 days — enough to walk back a
+bad eval without unbounded growth. Versioning only survives a bad write
+though, not the bucket going away, so AWS Backup takes a daily copy into a
+separate vault with 35-day retention.
+
 Config env vars: `SMEGGDROP_TRIGGER` (default `^\s*tcl\s`),
 `SMEGGDROP_CHANNELS` (comma-separated channel IDs, empty = all),
 `SMEGGDROP_BLOCKED_USERS` (comma-separated slack user IDs — not

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -38,6 +38,73 @@ export default $config({
     // versioned so a trashed proc library can be rolled back to any prior write
     const state = new sst.aws.Bucket("State", { versioning: true });
 
+    // The store packs a whole category into one object, so every eval that
+    // changes anything writes a full copy -- versions accumulate at roughly
+    // 6 MB per changing eval, not per changed proc. Keep enough history to
+    // undo a bad eval (or a bad day) without growing without bound.
+    new aws.s3.BucketLifecycleConfigurationV2("StateLifecycle", {
+      bucket: state.name,
+      rules: [
+        {
+          id: "retain-recent-versions",
+          status: "Enabled",
+          filter: {},
+          noncurrentVersionExpiration: {
+            newerNoncurrentVersions: 200,
+            noncurrentDays: 90,
+          },
+        },
+        {
+          id: "abort-incomplete-uploads",
+          status: "Enabled",
+          filter: {},
+          abortIncompleteMultipartUpload: { daysAfterInitiation: 7 },
+        },
+      ],
+    });
+
+    // Versioning only survives a bad write; it does not survive the bucket
+    // being deleted. A daily backup into a separate vault does.
+    const backupRole = new aws.iam.Role("StateBackupRole", {
+      assumeRolePolicy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Principal: { Service: "backup.amazonaws.com" },
+            Action: "sts:AssumeRole",
+          },
+        ],
+      }),
+    });
+    for (const [name, arn] of [
+      // these two live at the policy root, not under service-role/
+      ["Backup", "arn:aws:iam::aws:policy/AWSBackupServiceRolePolicyForS3Backup"],
+      ["Restore", "arn:aws:iam::aws:policy/AWSBackupServiceRolePolicyForS3Restore"],
+    ]) {
+      new aws.iam.RolePolicyAttachment(`StateBackupRole${name}`, {
+        role: backupRole.name,
+        policyArn: arn,
+      });
+    }
+
+    const vault = new aws.backup.Vault("StateVault", {});
+    const plan = new aws.backup.Plan("StatePlan", {
+      rules: [
+        {
+          ruleName: "daily",
+          targetVaultName: vault.name,
+          schedule: "cron(0 9 * * ? *)", // 09:00 UTC, off-peak for a chat bot
+          lifecycle: { deleteAfter: 35 },
+        },
+      ],
+    });
+    new aws.backup.Selection("StateSelection", {
+      iamRoleArn: backupRole.arn,
+      planId: plan.id,
+      resources: [state.arn],
+    });
+
     const botToken = new sst.Secret("SlackBotToken");
     const signingSecret = new sst.Secret("SlackSigningSecret");
     const channels = new sst.Secret("SlackChannels", "");


### PR DESCRIPTION
Stacked on #7.

Versioning was on but had two gaps. The store packs a whole category into one object, so every eval that changes anything rewrites ~6 MB — versions accumulate per *eval*, not per changed proc, and nothing was expiring them. And versioning doesn't survive the bucket being deleted.

So: keep the 200 most recent noncurrent versions / expire after 90 days, plus a daily AWS Backup into a separate vault with 35-day retention.

Verified with an on-demand backup job rather than waiting for the 09:00 UTC schedule to discover a broken role. Worth noting `AWSBackupServiceRolePolicyForS3Backup`/`Restore` live at the IAM policy root, not under `service-role/` where most backup policies sit — the service-role path fails with NoSuchEntity.