### PR TITLE
Grant the lambda self-invoke inside sst's own role policy

### DIFF
--- a/sst.config.ts
+++ b/sst.config.ts
@@ -141,7 +141,10 @@ export default $config({
           // exists, which is what took the deployed bot down.
           actions: ["lambda:InvokeFunction"],
           resources: [
-            $interpolate`arn:aws:lambda:${aws.getRegionOutput().name}:${aws.getCallerIdentityOutput().accountId}:function:${$app.name}-${$app.stage}-*`,
+            // "BotFunction" is this component's logical name, so the prefix
+            // stays put across the random suffix sst regenerates, without
+            // widening the grant to every function in the stack
+            $interpolate`arn:aws:lambda:${aws.getRegionOutput().name}:${aws.getCallerIdentityOutput().accountId}:function:${$app.name}-${$app.stage}-BotFunction-*`,
           ],
         },
       ],

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -130,23 +130,21 @@ export default $config({
           actions: ["s3:GetObject", "s3:PutObject", "s3:ListBucket"],
           resources: [state.arn, $interpolate`${state.arn}/*`],
         },
-      ],
-    });
-
-    // bolt's lazy listeners ack inside slack's 3s window and then re-invoke
-    // this same function to run the eval. Granted separately rather than via
-    // `permissions` because the function can't reference its own arn without
-    // a dependency cycle.
-    new aws.iam.RolePolicy("BotSelfInvoke", {
-      role: bot.nodes.role.name,
-      policy: bot.nodes.function.arn.apply((arn) =>
-        JSON.stringify({
-          Version: "2012-10-17",
-          Statement: [
-            { Effect: "Allow", Action: "lambda:InvokeFunction", Resource: arn },
+        {
+          // bolt's lazy listeners ack inside slack's 3s window and then
+          // re-invoke this same function to run the eval, so the role needs
+          // to be able to invoke it. Matched by name prefix rather than the
+          // function's own arn: referencing that here is a dependency cycle,
+          // and granting it through a separate aws.iam.RolePolicy silently
+          // stops working the moment sst recreates the role -- the policy
+          // stays bound to the old one while pulumi still believes it
+          // exists, which is what took the deployed bot down.
+          actions: ["lambda:InvokeFunction"],
+          resources: [
+            $interpolate`arn:aws:lambda:${aws.getRegionOutput().name}:${aws.getCallerIdentityOutput().accountId}:function:${$app.name}-${$app.stage}-*`,
           ],
-        }),
-      ),
+        },
+      ],
     });
 
     return {


### PR DESCRIPTION
The deployed bot went down the moment real traffic arrived — bolt acked, then couldn't re-invoke the function to run the eval, so every message got a 200 and no reply:

```
AccessDeniedException ... is not authorized to perform: lambda:InvokeFunction
  on resource: arn:aws:lambda:us-west-2:...:function:smeggdrop-prod-BotFunction-okruuhbo
```

The grant was a standalone `aws.iam.RolePolicy` attached to `bot.nodes.role`. sst recreated the function's role on a later deploy, leaving that policy bound to a role that no longer existed — while pulumi still believed the resource was healthy. Nothing reported drift; the permission had just quietly vanished. The failure mode is nasty because it only shows up under real Slack traffic: the ack path works fine, so the URL verification and every synthetic check still pass.

Moving the grant into the function's `permissions` puts it in the role policy sst manages, so it gets recreated with the role. Scoped by name prefix rather than the function's own arn, which would be a dependency cycle.

Verified by deleting the hand-patched policy first, so the test exercises only the IaC-managed one: `eval from mish in #tcl: 'expr {21*2}'` → `eval ok for mish: 42`.