### PR TITLE
Add a tested way to roll the proc library back

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,30 @@ bad eval without unbounded growth. Versioning only survives a bad write
 though, not the bucket going away, so AWS Backup takes a daily copy into a
 separate vault with 35-day retention.
 
+### Undoing a bad eval
+
+Someone trashes the library, you roll the object back:
+
+```sh
+./restore-state.sh list                    # versions, newest first
+./restore-state.sh restore procs <version> # put one back
+./restore-state.sh verify                  # does it still load?
+```
+
+Restoring copies the old version *forward*, so the state you rolled back
+from stays in history and the command prints the id to undo itself with.
+Nothing is destroyed by a restore, including a wrong one.
+
+Note the deployed bot reads state at cold start and holds it in memory, so
+a restore doesn't reach warm containers — redeploy, or wait for them to age
+out. Losing a couple of evals to that is the intended trade: the alternative
+is re-reading ~6 MB from S3 on every message.
+
+For a bucket-level loss rather than a bad write, the daily AWS Backup
+recovery point restores to a fresh bucket. Worth knowing that a completed S3
+backup reports `BackupSizeInBytes: 0` — that's AWS under-reporting, not an
+empty backup; a restore of one was verified byte-identical.
+
 Config env vars: `SMEGGDROP_TRIGGER` (default `^\s*tcl\s`),
 `SMEGGDROP_CHANNELS` (comma-separated channel IDs, empty = all),
 `SMEGGDROP_BLOCKED_USERS` (comma-separated slack user IDs — not

--- a/restore-state.sh
+++ b/restore-state.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# Roll the S3 proc library back to an earlier version.
+#
+# The store keeps one object per category, so a bad eval rewrites the whole
+# blob -- which is exactly what bucket versioning is for. Every write leaves
+# the previous copy intact, and restoring is copying an old version back over
+# the current one (which itself becomes a new version, so a restore is
+# reversible too).
+#
+#   ./restore-state.sh list                 # what can I roll back to?
+#   ./restore-state.sh restore procs <id>   # put that version back
+#   ./restore-state.sh verify               # does the live state still load?
+#
+# The bot reads state at cold start and caches it, so after a restore give it
+# a new container -- redeploy, or wait for the warm ones to age out.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+PROFILE="${SMEGGDROP_AWS_PROFILE:-smeggdrop}"
+REGION="${SMEGGDROP_AWS_REGION:-us-west-2}"
+BUCKET="${SMEGGDROP_STATE_BUCKET:-smeggdrop-prod-statebucket-obvshxns}"
+PREFIX="${SMEGGDROP_STATE_PREFIX:-state}"
+
+aws_() { aws --profile "$PROFILE" --region "$REGION" "$@"; }
+
+usage() { sed -n '3,20p' "$0" | sed 's/^# \{0,1\}//'; exit 1; }
+
+cmd_list() {
+    for cat in procs vars; do
+        echo "== $cat =="
+        aws_ s3api list-object-versions --bucket "$BUCKET" \
+            --prefix "$PREFIX/$cat.json" \
+            --query "reverse(sort_by(Versions, &LastModified))[].{When:LastModified,Size:Size,Current:IsLatest,Version:VersionId}" \
+            --output table
+    done
+}
+
+cmd_restore() {
+    local cat="${1:-}" ver="${2:-}"
+    case "$cat" in procs|vars) ;; *) echo "category must be procs or vars" >&2; exit 1;; esac
+    [ -n "$ver" ] || { echo "need a version id (see: $0 list)" >&2; exit 1; }
+
+    local key="$PREFIX/$cat.json"
+    local current
+    current=$(aws_ s3api head-object --bucket "$BUCKET" --key "$key" --query VersionId --output text)
+    echo "current version of $key is $current"
+    echo "restoring $ver over it..."
+    # copying an old version forward keeps the current one as history, so
+    # this is undoable: re-run with the id printed above
+    aws_ s3api copy-object --bucket "$BUCKET" --key "$key" \
+        --copy-source "$BUCKET/$key?versionId=$ver" \
+        --metadata-directive COPY --query 'CopyObjectResult.ETag' --output text
+    echo "done. to undo: $0 restore $cat $current"
+}
+
+cmd_verify() {
+    local uri="s3://$BUCKET/$PREFIX"
+    echo "loading $uri into a throwaway interpreter..."
+    AWS_PROFILE="$PROFILE" AWS_REGION="$REGION" \
+        uv run --quiet --with boto3 smeggdrop --state "$uri" audit --json 2>/dev/null \
+        | uv run --quiet python -c '
+import json, sys
+r = json.load(sys.stdin)
+tot = r.get("total") or len(r.get("procs", []))
+bad = r.get("load_errors") or 0
+print(f"procs loaded: {tot}   load errors: {bad}")
+sys.exit(1 if bad else 0)'
+}
+
+case "${1:-}" in
+    list)    cmd_list ;;
+    restore) shift; cmd_restore "$@" ;;
+    verify)  cmd_verify ;;
+    *)       usage ;;
+esac

--- a/restore-state.sh
+++ b/restore-state.sh
@@ -8,10 +8,6 @@
 # the current one (which itself becomes a new version, so a restore is
 # reversible too).
 #
-#   ./restore-state.sh list                 # what can I roll back to?
-#   ./restore-state.sh restore procs <id>   # put that version back
-#   ./restore-state.sh verify               # does the live state still load?
-#
 # The bot reads state at cold start and caches it, so after a restore give it
 # a new container -- redeploy, or wait for the warm ones to age out.
 set -euo pipefail
@@ -24,7 +20,19 @@ PREFIX="${SMEGGDROP_STATE_PREFIX:-state}"
 
 aws_() { aws --profile "$PROFILE" --region "$REGION" "$@"; }
 
-usage() { sed -n '3,20p' "$0" | sed 's/^# \{0,1\}//'; exit 1; }
+usage() {
+    cat >&2 <<'EOF'
+roll the S3 proc library back to an earlier version
+
+  ./restore-state.sh list                    versions, newest first
+  ./restore-state.sh restore procs <version> put one back
+  ./restore-state.sh verify                  does the live state still load?
+
+override with SMEGGDROP_AWS_PROFILE / SMEGGDROP_AWS_REGION /
+SMEGGDROP_STATE_BUCKET / SMEGGDROP_STATE_PREFIX
+EOF
+    exit 1
+}
 
 cmd_list() {
     for cat in procs vars; do
@@ -44,12 +52,18 @@ cmd_restore() {
     local key="$PREFIX/$cat.json"
     local current
     current=$(aws_ s3api head-object --bucket "$BUCKET" --key "$key" --query VersionId --output text)
+
+    # version ids are opaque and routinely contain +, / and =, all of which
+    # change meaning inside a copy-source. Encode before interpolating.
+    local ver_enc
+    ver_enc=$(python3 -c 'import sys,urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$ver")
+
     echo "current version of $key is $current"
     echo "restoring $ver over it..."
     # copying an old version forward keeps the current one as history, so
     # this is undoable: re-run with the id printed above
     aws_ s3api copy-object --bucket "$BUCKET" --key "$key" \
-        --copy-source "$BUCKET/$key?versionId=$ver" \
+        --copy-source "$BUCKET/$key?versionId=$ver_enc" \
         --metadata-directive COPY --query 'CopyObjectResult.ETag' --output text
     echo "done. to undo: $0 restore $cat $current"
 }
@@ -57,15 +71,26 @@ cmd_restore() {
 cmd_verify() {
     local uri="s3://$BUCKET/$PREFIX"
     echo "loading $uri into a throwaway interpreter..."
+    # stderr is left alone: when this fails it is usually aws auth or a
+    # missing dependency, and swallowing that turns a clear error into a
+    # bare non-zero exit
+    local report
+    report=$(mktemp)
+    # shellcheck disable=SC2064
+    trap "rm -f '$report'" RETURN
+    # to a file rather than a pipe: exiting non-zero from the reader closes
+    # the pipe under the writer, and the BrokenPipeError that follows buries
+    # the actual result
     AWS_PROFILE="$PROFILE" AWS_REGION="$REGION" \
-        uv run --quiet --with boto3 smeggdrop --state "$uri" audit --json 2>/dev/null \
-        | uv run --quiet python -c '
+        uv run --quiet --with boto3 smeggdrop --state "$uri" audit --json > "$report"
+    python3 - "$report" <<'PY'
 import json, sys
-r = json.load(sys.stdin)
-tot = r.get("total") or len(r.get("procs", []))
-bad = r.get("load_errors") or 0
-print(f"procs loaded: {tot}   load errors: {bad}")
-sys.exit(1 if bad else 0)'
+s = json.load(open(sys.argv[1]))["summary"]
+bad = s["load_failures"] + s["var_load_failures"]
+print(f"procs: {s['total']}   load failures: {s['load_failures']}"
+      f"   var load failures: {s['var_load_failures']}")
+sys.exit(1 if bad else 0)
+PY
 }
 
 case "${1:-}" in


### PR DESCRIPTION
Versioning was already on, but there was no procedure for actually using it — which is the part that matters at the moment someone trashes the library.

`restore-state.sh` lists versions, restores one, and re-loads the result to check it. Restoring copies the old version *forward* rather than deleting anything, so the state you rolled back from stays in history and the command prints the id to undo itself with. A wrong restore is recoverable too.

Verified against the live bucket rather than a fixture: rolled `procs.json` back, confirmed the content matched the target version, and loaded the result — 6,620 procs, 0 load errors. (Safe to do on production because both versions had identical ETags, so the round trip changed no content.)

Also documents two things that would otherwise bite someone at 3am: warm Lambda containers hold state in memory so a restore doesn't reach them until they recycle, and a completed S3 backup reports `BackupSizeInBytes: 0` — that's AWS under-reporting, not an empty backup, confirmed by a byte-identical restore.