### PR TITLE
Share the event-id claim so two containers can't both answer

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ Config env vars: `SMEGGDROP_TRIGGER` (default `^\s*tcl\s`),
 `SMEGGDROP_BLOCKED_USERS` (comma-separated slack user IDs — not
 names, which anyone can change — silently ignored, no reply),
 `SMEGGDROP_STATE`, `SMEGGDROP_TIME_LIMIT`, `SMEGGDROP_WORDS`,
-`SMEGGDROP_MEMORY_MB` (default 2048, 0 disables).
+`SMEGGDROP_MEMORY_MB` (default 2048, 0 disables),
+`SMEGGDROP_DEDUPE_TABLE` (dynamo table for cross-container dedupe).
 
 Request signatures are verified by bolt. Each slack event id runs at most
 once, but a retry whose first delivery was never acked — the bot was
@@ -115,6 +116,16 @@ restarting — still runs, instead of being dropped for merely looking like a
 retry. On lambda one event arrives as two invocations carrying the same
 event id (ack, then eval), so bolt's own re-invocation is exempt from that
 check; deduping it would drop every eval.
+
+Where that claim is kept matters. In one process an in-memory record is
+enough, but on lambda "one process" means "one container": Slack retries an
+event it hasn't seen acked within 3s — which a cold start is right on the
+edge of — and the retry is free to land on a container that has never heard
+of it. Both run the eval and the channel gets answered twice, which is how
+it showed up in practice. Set `SMEGGDROP_DEDUPE_TABLE` to a dynamo table and
+the claim becomes a conditional write every container can see; leave it
+unset for socket mode, where in-memory is correct. If dynamo is unreachable
+the event runs rather than being dropped — a duplicate answer beats silence.
 
 `audit` exists so the port can be verified against real accumulated state:
 it loads everything into a throwaway sandbox (nothing persisted, network

--- a/smeggdrop/platforms/slack.py
+++ b/smeggdrop/platforms/slack.py
@@ -43,6 +43,9 @@ class SlackConfig:
     time_limit: int = 5
     words_file: str | None = None
     app_token: str | None = None  # xapp-, socket mode only
+    # dynamo table for cross-container dedupe; empty = in-memory, which
+    # is only correct when there is a single process (socket mode)
+    dedupe_table: str | None = None
 
     @classmethod
     def from_env(cls, env=os.environ) -> "SlackConfig":
@@ -63,6 +66,7 @@ class SlackConfig:
             time_limit=int(env.get("SMEGGDROP_TIME_LIMIT", "5")),
             words_file=env.get("SMEGGDROP_WORDS") or None,
             app_token=env.get("SLACK_APP_TOKEN") or None,
+            dedupe_table=env.get("SMEGGDROP_DEDUPE_TABLE") or None,
         )
 
 
@@ -196,6 +200,61 @@ class EventDeduper:
         while len(self._seen) > self.capacity:
             self._seen.popitem(last=False)
         return True
+
+
+class DynamoDeduper:
+    """Claims slack event ids in dynamo, so the claim is shared.
+
+    EventDeduper keeps its record in memory, which means per process — and
+    on lambda that means per container. Slack retries when it doesn't get an
+    ack inside 3s, which a cold start is right on the edge of, and the retry
+    is free to land on a *different* container that has never heard of the
+    event. It runs the eval again and the channel gets two answers. Only a
+    claim both containers can see fixes that.
+
+    The claim is a conditional write: first writer wins, everyone else is a
+    duplicate. Items carry a TTL because the claim only has to outlive
+    slack's retry window, not be kept forever.
+    """
+
+    def __init__(self, table: str, ttl_seconds: int = 900, client=None):
+        self.table = table
+        self.ttl_seconds = ttl_seconds
+        self._client = client
+
+    @property
+    def client(self):
+        if self._client is None:
+            import boto3  # imported lazily so the core stays dependency-free
+
+            self._client = boto3.client("dynamodb")
+        return self._client
+
+    def claim(self, event_id: str | None) -> bool:
+        if not event_id:
+            return True  # nothing to dedupe on; better to run than to drop
+        try:
+            self.client.put_item(
+                TableName=self.table,
+                Item={
+                    "event_id": {"S": event_id},
+                    "expires_at": {"N": str(int(time.time()) + self.ttl_seconds)},
+                },
+                ConditionExpression="attribute_not_exists(event_id)",
+            )
+            return True
+        except Exception as e:
+            if type(e).__name__ == "ConditionalCheckFailedException":
+                return False
+            # A dynamo outage must not take the bot down with it. Answering
+            # twice is a worse failure than not answering at all, so fall
+            # back to running the event rather than dropping it.
+            log.warning("dedupe claim failed for %s, running anyway: %s", event_id, e)
+            return True
+
+
+def make_deduper(cfg: "SlackConfig"):
+    return DynamoDeduper(cfg.dedupe_table) if cfg.dedupe_table else EventDeduper()
 
 
 def event_id_of(body) -> str | None:
@@ -452,7 +511,7 @@ def build_app(engine: Engine, cfg: SlackConfig, *, lazy: bool = False, **app_kwa
     nicks = NickCache()
     channels = ChannelCache()
     chat_log = ChatLog()
-    deduper = EventDeduper()
+    deduper = make_deduper(cfg)
 
     @app.middleware
     def drop_duplicates(request, next):

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -105,6 +105,17 @@ export default $config({
       resources: [state.arn],
     });
 
+    // Slack retries an event it didn't see acked within 3s, which a cold
+    // start sits right on the edge of, and the retry can land on a different
+    // container. An in-memory dedupe is per container, so both of them run
+    // the eval and the channel gets answered twice -- the claim has to be
+    // somewhere both can see it.
+    const dedupe = new sst.aws.Dynamo("Dedupe", {
+      fields: { event_id: "string" },
+      primaryIndex: { hashKey: "event_id" },
+      ttl: "expires_at",
+    });
+
     const botToken = new sst.Secret("SlackBotToken");
     const signingSecret = new sst.Secret("SlackSigningSecret");
     const channels = new sst.Secret("SlackChannels", "");
@@ -124,11 +135,16 @@ export default $config({
         SMEGGDROP_CHANNELS: channels.value,
         SMEGGDROP_STATE: $interpolate`s3://${state.name}/state`,
         SMEGGDROP_TIME_LIMIT: "5",
+        SMEGGDROP_DEDUPE_TABLE: dedupe.name,
       },
       permissions: [
         {
           actions: ["s3:GetObject", "s3:PutObject", "s3:ListBucket"],
           resources: [state.arn, $interpolate`${state.arn}/*`],
+        },
+        {
+          actions: ["dynamodb:PutItem"],
+          resources: [dedupe.arn],
         },
         {
           // bolt's lazy listeners ack inside slack's 3s window and then

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -325,6 +325,68 @@ def test_event_deduper_is_bounded():
     assert d.claim("Ev0") is True  # oldest evicted
 
 
+class FakeDynamo:
+    """Minimal conditional-put dynamo: first writer for a key wins."""
+
+    class ConditionalCheckFailedException(Exception):
+        pass
+
+    def __init__(self, fail_with=None):
+        self.items: dict[str, dict] = {}
+        self.fail_with = fail_with
+
+    def put_item(self, *, TableName, Item, ConditionExpression=None):
+        if self.fail_with:
+            raise self.fail_with
+        key = Item["event_id"]["S"]
+        if ConditionExpression and key in self.items:
+            raise FakeDynamo.ConditionalCheckFailedException()
+        self.items[key] = Item
+
+
+def test_dynamo_deduper_claims_once_across_instances():
+    from smeggdrop.platforms.slack import DynamoDeduper
+
+    # two instances standing in for two lambda containers: the whole point is
+    # that the second one knows the first already took the event
+    shared = FakeDynamo()
+    a = DynamoDeduper("t", client=shared)
+    b = DynamoDeduper("t", client=shared)
+    assert a.claim("Ev1") is True
+    assert b.claim("Ev1") is False
+    assert b.claim("Ev2") is True
+    assert a.claim(None) is True  # nothing to dedupe on: run it
+
+
+def test_dynamo_deduper_sets_a_ttl():
+    from smeggdrop.platforms.slack import DynamoDeduper
+
+    shared = FakeDynamo()
+    DynamoDeduper("t", ttl_seconds=900, client=shared).claim("Ev1")
+    assert int(shared.items["Ev1"]["expires_at"]["N"]) > 0
+
+
+def test_dynamo_deduper_runs_the_event_when_dynamo_is_down():
+    from smeggdrop.platforms.slack import DynamoDeduper
+
+    # answering twice is worse than answering once, but not answering at all
+    # is worse still — a dedupe outage must not silence the bot
+    d = DynamoDeduper("t", client=FakeDynamo(fail_with=RuntimeError("boom")))
+    assert d.claim("Ev1") is True
+
+
+def test_make_deduper_picks_by_config():
+    from smeggdrop.platforms.slack import (
+        DynamoDeduper,
+        EventDeduper,
+        SlackConfig,
+        make_deduper,
+    )
+
+    assert isinstance(make_deduper(SlackConfig()), EventDeduper)
+    assert isinstance(make_deduper(SlackConfig(dedupe_table="t")), DynamoDeduper)
+
+
 def test_capitalized_trigger_works_end_to_end(engine, cfg):
     client = StubClient()
     assert handle_message_event(engine, client, event("Tcl expr {6 * 7}"), cfg)


### PR DESCRIPTION
The deployed bot answered mish twice. Two containers ran the same event three seconds apart:

```
02:23:03  container 2951846a  eval ok for mish: 90% of my wardrobe...
02:23:06  container 1c52d62e  eval ok for mish: I was hungry as fuck...
```

`EventDeduper` keeps its record in memory — per process, which on lambda means per *container*. Slack retries an event it hasn't seen acked within 3s, which our ~3s cold start sits right on the edge of, and the retry is free to land on a container that has never heard of it. Both run the eval. Different output each time because `fatgoon` is random, so it reads as two answers rather than an obvious repeat.

This was mine: the dedupe was written for socket mode, where one process really is the whole world, and I carried it to lambda without revisiting that assumption. Nothing catches it in tests or in synthetic checks — it needs two live containers and a retry.

Claims now go to dynamo as a conditional write when `SMEGGDROP_DEDUPE_TABLE` is set. Socket mode leaves it unset and keeps the in-memory path. A dynamo outage falls back to *running* the event: answering twice is bad, answering not at all is worse.

Verified against the deployed function — same event id delivered twice, one processed, one `dropping duplicate delivery of Ev_dupetest_... (retry 1)`, and the claim visible in the table.