### PR TITLE
Log plain chat that addresses the operator by name

### DIFF
--- a/smeggdrop/platforms/slack.py
+++ b/smeggdrop/platforms/slack.py
@@ -71,6 +71,10 @@ CHANNEL_MENTION = re.compile(r"<#[C][A-Z0-9]+(?:\|([^>]*))?>")
 BROADCAST_MENTION = re.compile(r"<!(here|channel|everyone)(?:\|[^>]*)?>")
 SPECIAL_MENTION = re.compile(r"<!([a-z_]+)(?:\^[^|>]*)?(?:\|([^>]*))?>")
 
+# The bot has no slack identity of its own to be @-mentioned, so this is
+# the only way "is claude around" is distinguishable from ordinary chat.
+OPERATOR_MENTION = re.compile(r"\bclaude\b", re.IGNORECASE)
+
 
 def unfuck_slack_message(text: str) -> str:
     """Undo slack's message mangling before trigger matching: unescape html
@@ -338,6 +342,13 @@ def handle_message_event(
     if code is None or not code.strip():
         if chat_log is not None and cleaned:
             chat_log.append(channel, nick, user_id or None, cleaned)
+        if cleaned and OPERATOR_MENTION.search(cleaned):
+            # plain chat never otherwise produces a log line, so someone
+            # addressing the operator by name is invisible unless it's
+            # logged on purpose. This doesn't page or reply -- a human is
+            # expected to be watching the logs.
+            channel_name = (channels or ChannelCache()).resolve(client, channel)
+            log.info("mention: %s in %s: %r", nick, channel_name, cleaned[:200])
         return False
 
     channel_name = (channels or ChannelCache()).resolve(client, channel)

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -63,6 +63,24 @@ def test_non_trigger_ignored(engine, cfg):
     assert client.posted == []
 
 
+def test_mention_is_logged_but_not_evaluated_or_replied(engine, cfg, caplog):
+    # the bot has no slack identity to be @-mentioned, so this is the only
+    # signal an operator watching the logs gets that someone's asking for
+    # them by name
+    client = StubClient()
+    with caplog.at_level("INFO"):
+        assert not handle_message_event(engine, client, event("is claude around?"), cfg)
+    assert client.posted == []  # never replies on the channel's behalf
+    assert any("mention: " in r.message and "claude" in r.message.lower() for r in caplog.records)
+
+
+def test_mention_matches_whole_word_only(engine, cfg, caplog):
+    client = StubClient()
+    with caplog.at_level("INFO"):
+        assert not handle_message_event(engine, client, event("claudette said hi"), cfg)
+    assert not any(r.message.startswith("mention: ") for r in caplog.records)
+
+
 def test_bot_messages_never_evaluated(engine, cfg):
     client = StubClient()
     assert not handle_message_event(


### PR DESCRIPTION
There's no way to see "is claude around" happening. The bot has no slack identity to be @-mentioned, and plain chat that doesn't match the tcl trigger produces no log line at all — an operator watching CloudWatch was blind to it entirely, which is how this came up: mish asked in channel and there was nothing in the logs.

Matches "claude" as a whole word, case-insensitive, and logs it with the channel name resolved the same way an eval log does. Doesn't reply or otherwise act on it — a human is expected to be watching.