### PR TITLE
Alias puts to core::print instead of erroring on no stdout

### DIFF
--- a/smeggdrop/tcl/bootstrap.tcl
+++ b/smeggdrop/tcl/bootstrap.tcl
@@ -77,3 +77,32 @@ proc apply {cmd args} {
 namespace eval commands {
     proc words {} { core::words }
 }
+
+# `puts` is ordinary Tcl, but a safe interp starts with no channels shared
+# in at all, so a bare [puts $x] fails with "can not find channel named
+# stdout" -- the first thing anyone reaches for by habit. There has never
+# been a real stdout here to write to: this bot's output is the eval's
+# return value (or core::bot_say), not anything printed along the way, so
+# nothing in the accumulated state actually calls puts. Alias it to
+# core::print rather than leaving newcomers to hit a channel error that
+# has nothing to do with what they were trying to do -- same as core::print
+# always did, output goes to the operator's log, not the channel.
+proc puts {args} {
+    if {[llength $args] && [lindex $args 0] eq "-nonewline"} {
+        set args [lrange $args 1 end]
+    }
+    switch [llength $args] {
+        1 { core::print [lindex $args 0] }
+        2 {
+            set chan [lindex $args 0]
+            if {$chan ni {stdout stderr}} {
+                error "can not find channel named \"$chan\""
+            }
+            core::print [lindex $args 1]
+        }
+        default {
+            error {wrong # args: should be "puts ?-nonewline? ?channelId? string"}
+        }
+    }
+    return
+}

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -274,6 +274,49 @@ def test_builtin_apply_stays_reachable(engine):
     assert run(engine, "tcl_apply {{x} {return $x}} ok").output == "ok"
 
 
+def test_puts_no_longer_hits_missing_channel(engine):
+    # a safe interp shares in no channels, so a bare [puts] used to fail
+    # with "can not find channel named stdout" -- the first thing anyone
+    # reaches for by ordinary tcl habit, unrelated to what they meant to do
+    for code in ("puts hi", "puts stdout hi", "puts stderr hi", "puts -nonewline hi"):
+        result = run(engine, code)
+        assert result.ok, f"{code!r} -> {result.output}"
+
+
+def test_puts_output_goes_to_the_operator_log_not_the_channel(engine, caplog):
+    # matches core::print, which this is an alias for: this bot's visible
+    # output has only ever been the eval's return value or core::bot_say,
+    # so puts becoming non-fatal must not quietly start posting into slack
+    with caplog.at_level("INFO"):
+        result = run(engine, 'puts "hello there"')
+    assert result.ok
+    assert result.output == ""
+    assert any("hello there" in r.message for r in caplog.records)
+
+
+def test_puts_bogus_channel_still_errors(engine):
+    result = run(engine, "puts notachannel hi")
+    assert not result.ok
+    assert "notachannel" in result.output
+
+
+def test_puts_wrong_arg_count_still_errors(engine):
+    result = run(engine, "puts a b c")
+    assert not result.ok
+
+
+def test_puts_works_inside_a_loop(engine):
+    # the actual case that surfaced this: a proc looping over a list and
+    # puts-ing each element like an ordinary tcl script would
+    run(engine, "set ::items {a b c}")
+    result = run(
+        engine,
+        "for {set i 0} {$i < [llength $::items]} {incr i} "
+        '{puts "$i: [lindex $::items $i]"}',
+    )
+    assert result.ok
+
+
 def test_reload_picks_up_externally_written_state(store, engine):
     # simulate a one-off `smeggdrop repl` fix landing on disk while the
     # engine is already running, the exact scenario hot reload is for


### PR DESCRIPTION
A safe interp shares in no channels at all, so a bare `puts` fails with "can not find channel named stdout" — the first thing anyone reaches for by ordinary tcl habit, unrelated to whatever they were actually trying to do. Surfaced live: Vor writing a debug proc that loops and puts each element.

There was never a real stdout here to write to, on the perl bot or this one — output has only ever been the eval's return value, or `core::bot_say`. That's why zero procs in 6,612 accumulated since 2007 use bare `puts`: it was never useful, not a regression. So this doesn't invent a new visible-output path (which would need its own limits and security review) — it aliases `puts` to `core::print`, which already exists and already has the right shape: operator log, not the channel, no new capability. A bogus channel name or wrong arg count still errors like real tcl.

Audited clean against the accumulated hardchats state: 6,612 procs, 0 load failures — same numbers as before the change.